### PR TITLE
repo: use system-provided stdlib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -531,3 +531,4 @@ docs/custom_html
 .svelte-kit
 
 # End of https://www.toptal.com/developers/gitignore/api/node
+toolchain/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ project(haxorg LANGUAGES CXX)
 set(BASE "${CMAKE_SOURCE_DIR}")
 message(STATUS "CMAKE_SOURCE_DIR = ${CMAKE_SOURCE_DIR}")
 set(LLVM_DIR "${BASE}/toolchain/llvm")
+set(TOOLCHAIN_DIR "${BASE}/toolchain")
 
 set(AUTOGEN_BUILD_DIR "${BASE}/build/autogen")
 set(SCRIPT_DIR "${BASE}/src/scripts")
@@ -29,23 +30,44 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 # with LLVM
 set(LLVM_GNU_CLANG_DIR "${LLVM_DIR}/lib/clang/17/lib/x86_64-unknown-linux-gnu")
 # Standard library, libc++.so and other things
-set(LLVM_STD_DIRS "${LLVM_DIR}/lib/x86_64-unknown-linux-gnu")
+# set(LLVM_STD_DIRS "${TOOLCHAIN_DIR}/std_binaries/usr/lib/x86_64-linux-gnu")
 # Declare variable for the asan library path, it is used in target setups, this
 # is not some specific variable that is implicitly consumed, just declared it here
 set(LLVM_ASAN_LIBRARY "${LLVM_GNU_CLANG_DIR}/libclang_rt.asan.so")
-# Headers that standard library apparently uses to interface with the system?
-set(LLVM_GNU_INCLUDE "${LLVM_DIR}/include/x86_64-unknown-linux-gnu/c++/v1")
+set(PACKAGED_STD_VERSION "14")
+# Include file config path
+# set(LLVM_GNU_INCLUDE "${TOOLCHAIN_DIR}/std_headers/usr/include/x86_64-linux-gnu/c++/${PACKAGED_STD_VERSION}/")
 # Standard library headers
-set(LLVM_STD_INCLUDE "${LLVM_DIR}/include/c++/v1/")
+# set(LLVM_STD_INCLUDE "${TOOLCHAIN_DIR}/std_headers/usr/include/c++/${PACKAGED_STD_VERSION}")
+
+message(STATUS "[DBG] LLVM_STD_INCLUDE = ${LLVM_STD_INCLUDE}")
+# message(STATUS "[DBG] LLVM_ASAN_LIBRARY = ${LLVM_ASAN_LIBRARY}")
+# message(STATUS "[DBG] LLVM_STD_DIRS = ${LLVM_STD_DIRS}")
+message(STATUS "[DBG] LLVM_GNU_CLANG_DIR = ${LLVM_GNU_CLANG_DIR}")
+# message(STATUS "[DBG] LLVM_GNU_INCLUDE = ${LLVM_GNU_INCLUDE}")
+
+
+# set(CMAKE_FLAGS_LIST
+#     "-nostdinc++"
+#     "-nostdlib"
+#     # "-stdlib=libstdc++"
+#     "-Wno-unused-command-line-argument"
+#     "-isystem" "${LLVM_STD_INCLUDE}"
+#     "-isystem" "${LLVM_GNU_INCLUDE}"
+#     "-ftemplate-backtrace-limit=0"
+#     "-L${TOOLCHAIN_DIR}/std_binaries/usr/lib/x86_64-linux-gnu"
+# )
+
+string(JOIN " " CMAKE_FLAGS_TMP ${CMAKE_FLAGS_LIST})
 
 # Globally configure compiler flags with all necessary flags etc., this will be shared 
-# down to all sub-components and dependencies. 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -Wno-unused-command-line-argument -I${LLVM_STD_INCLUDE} -I${LLVM_GNU_INCLUDE} -L${LLVM_DIR}/lib -ftemplate-backtrace-limit=0")
+# down to all sub-components and dependencies.
+# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_FLAGS_TMP}")
 # It is important to specify linker flags globally for the whole project here -- benchmark
 # subdirectory depends on the cxx_feature_check which fails if the shared parts of the standard
 # library are not found. Regex check compiles test code, everything is ok, but running
 # would fail without adding stdc++ runtime search paths
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-rpath,${LLVM_GNU_CLANG_DIR},-rpath,${LLVM_STD_DIRS}")
+# set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-rpath,${LLVM_GNU_CLANG_DIR},-rpath,${LLVM_STD_DIRS}")
 
 file(MAKE_DIRECTORY ${AUTOGEN_BUILD_DIR})
 list(PREPEND CMAKE_MODULE_PATH ${DEPS_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,45 +29,13 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 # Directory with clang-related runtime libraries such as asan that are shipped 
 # with LLVM
 set(LLVM_GNU_CLANG_DIR "${LLVM_DIR}/lib/clang/17/lib/x86_64-unknown-linux-gnu")
-# Standard library, libc++.so and other things
-# set(LLVM_STD_DIRS "${TOOLCHAIN_DIR}/std_binaries/usr/lib/x86_64-linux-gnu")
 # Declare variable for the asan library path, it is used in target setups, this
 # is not some specific variable that is implicitly consumed, just declared it here
 set(LLVM_ASAN_LIBRARY "${LLVM_GNU_CLANG_DIR}/libclang_rt.asan.so")
 set(PACKAGED_STD_VERSION "14")
-# Include file config path
-# set(LLVM_GNU_INCLUDE "${TOOLCHAIN_DIR}/std_headers/usr/include/x86_64-linux-gnu/c++/${PACKAGED_STD_VERSION}/")
-# Standard library headers
-# set(LLVM_STD_INCLUDE "${TOOLCHAIN_DIR}/std_headers/usr/include/c++/${PACKAGED_STD_VERSION}")
 
 message(STATUS "[DBG] LLVM_STD_INCLUDE = ${LLVM_STD_INCLUDE}")
-# message(STATUS "[DBG] LLVM_ASAN_LIBRARY = ${LLVM_ASAN_LIBRARY}")
-# message(STATUS "[DBG] LLVM_STD_DIRS = ${LLVM_STD_DIRS}")
 message(STATUS "[DBG] LLVM_GNU_CLANG_DIR = ${LLVM_GNU_CLANG_DIR}")
-# message(STATUS "[DBG] LLVM_GNU_INCLUDE = ${LLVM_GNU_INCLUDE}")
-
-
-# set(CMAKE_FLAGS_LIST
-#     "-nostdinc++"
-#     "-nostdlib"
-#     # "-stdlib=libstdc++"
-#     "-Wno-unused-command-line-argument"
-#     "-isystem" "${LLVM_STD_INCLUDE}"
-#     "-isystem" "${LLVM_GNU_INCLUDE}"
-#     "-ftemplate-backtrace-limit=0"
-#     "-L${TOOLCHAIN_DIR}/std_binaries/usr/lib/x86_64-linux-gnu"
-# )
-
-string(JOIN " " CMAKE_FLAGS_TMP ${CMAKE_FLAGS_LIST})
-
-# Globally configure compiler flags with all necessary flags etc., this will be shared 
-# down to all sub-components and dependencies.
-# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_FLAGS_TMP}")
-# It is important to specify linker flags globally for the whole project here -- benchmark
-# subdirectory depends on the cxx_feature_check which fails if the shared parts of the standard
-# library are not found. Regex check compiles test code, everything is ok, but running
-# would fail without adding stdc++ runtime search paths
-# set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-rpath,${LLVM_GNU_CLANG_DIR},-rpath,${LLVM_STD_DIRS}")
 
 file(MAKE_DIRECTORY ${AUTOGEN_BUILD_DIR})
 list(PREPEND CMAKE_MODULE_PATH ${DEPS_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,7 @@ add_subdirectory("${DEPS_DIR}/pybind11")
 
 add_subdirectory("${DEPS_DIR}/abseil-cpp")
 add_subdirectory("${DEPS_DIR}/googletest")
+add_subdirectory("${DEPS_DIR}/SQLiteCpp")
 
 
 set(protobuf_INSTALL OFF)
@@ -138,3 +139,4 @@ include(src/cmake/target_pyhaxorg.cmake)
 include(src/cmake/target_lsp.cmake)
 
 add_subdirectory(scripts/cxx_repository)
+add_subdirectory(scripts/cxx_codegen)

--- a/invoke-ci.yaml
+++ b/invoke-ci.yaml
@@ -11,6 +11,7 @@ tasks:
 
 force_task: [
   "python_protobuf_files",
+  "update_py_haxorg_reflection",
 ]
 
  

--- a/invoke.yaml
+++ b/invoke.yaml
@@ -12,6 +12,7 @@ tasks:
 force_task: [
   # "cmake_configure_haxorg",
   # "cmake_haxorg",
+  "update_py_haxorg_reflection",
   "python_protobuf_files",
 ]
 

--- a/scripts/cxx_codegen/CMakeLists.txt
+++ b/scripts/cxx_codegen/CMakeLists.txt
@@ -2,28 +2,14 @@ cmake_minimum_required(VERSION 3.10)
 
 project(ConvertConstRef)
 
-set(BASE "${CMAKE_SOURCE_DIR}/../..")
+set(BASE "${CMAKE_SOURCE_DIR}")
+message(STATUS "BASE(cxx_codegen) = ${BASE}")
 # Specify the path to the LLVM toolchain
 set(TOOLCHAIN "${BASE}/toolchain")
 # Set the LLVM_DIR to the location of LLVMConfig.cmake
 set(LLVM_DIR "${TOOLCHAIN}/llvm/lib/cmake/llvm")
 set(Clang_DIR "${TOOLCHAIN}/llvm/lib/cmake/clang")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
-
-set(DEPS_DIR "${BASE}/thirdparty")
-
-add_subdirectory("${DEPS_DIR}/abseil-cpp" "${CMAKE_BINARY_DIR}/abseil_build")
-
-set(protobuf_INSTALL OFF)
-set(protobuf_BUILD_TESTS OFF)
-set(utf8_range_ENABLE_TESTS OFF)
-set(utf8_range_ENABLE_INSTALL OFF)
-
-set(PROTOBUF_BINARY "${CMAKE_BINARY_DIR}/protobuf_build")
-add_subdirectory("${DEPS_DIR}/protobuf" "${PROTOBUF_BINARY}")
-include("${DEPS_DIR}/protobuf/cmake/protobuf-generate.cmake")
-
-set(LLVM_LIB_DIR "${TOOLCHAIN}/llvm/lib")
 
 # Find the LLVM package. This also defines a lot of variables, see:
 # https://llvm.org/docs/CMake.html#embedding-llvm-in-your-project

--- a/scripts/cxx_codegen/profdata_merger/CMakeLists.txt
+++ b/scripts/cxx_codegen/profdata_merger/CMakeLists.txt
@@ -1,14 +1,7 @@
 add_executable(profdata_merger profdata_merger.cpp)
 llvm_map_components_to_libnames(profdata_merger_llvm_libs support core irreader profiledata coverage)
 
-set(SQLCPP_DIR "${BASE}/thirdparty/SQLiteCpp")
-add_subdirectory("${SQLCPP_DIR}" "${CMAKE_BINARY_DIR}/sqlitecpp_build")
-
 message(STATUS ${profdata_merger_llvm_libs})
-
-
-add_library(perfetto STATIC "${DEPS_DIR}/perfetto/sdk/perfetto.cc")
-target_include_directories(perfetto PUBLIC "${DEPS_DIR}/perfetto/sdk")
 
 target_link_libraries(profdata_merger
     ${profdata_merger_llvm_libs}

--- a/scripts/cxx_codegen/reflection_tool/CMakeLists.txt
+++ b/scripts/cxx_codegen/reflection_tool/CMakeLists.txt
@@ -23,8 +23,10 @@ add_library(
   ${ORG_PROTO_GENERATED_FILES})
 
 target_include_directories(
-  reflection_lib PUBLIC ${CMAKE_CURRENT_BINARY_DIR} "${DEPS_DIR}/protobuf/src"
-                        "${DEPS_DIR}/abseil-cpp")
+  reflection_lib
+  PUBLIC ${CMAKE_CURRENT_BINARY_DIR} "${DEPS_DIR}/protobuf/src"
+         "${DEPS_DIR}/abseil-cpp"
+         "${BASE}/build/haxorg/scripts/cxx_codegen/reflection_tool")
 
 target_link_libraries(reflection_lib ${PROTOBUF_LIBRARIES})
 target_compile_options(reflection_lib PRIVATE "-fPIC")

--- a/scripts/cxx_codegen/reflection_tool/clang_reflection_tool.cpp
+++ b/scripts/cxx_codegen/reflection_tool/clang_reflection_tool.cpp
@@ -41,6 +41,12 @@ llvm::cl::opt<bool> VerboseRun(
     llvm::cl::desc("Run compilation in verbose mode"),
     llvm::cl::cat(ToolingSampleCategory));
 
+
+llvm::cl::opt<bool> NoStdInc(
+    "nostdinc",
+    llvm::cl::desc("No STD include"),
+    llvm::cl::cat(ToolingSampleCategory));
+
 llvm::cl::opt<std::string> TargetFiles(
     "target-files",
     llvm::cl::desc("File with json array, list of absolute paths whose "
@@ -212,14 +218,13 @@ clang::tooling::CommandLineArguments dropReflectionPLugin(
      * reflection tool to actually construct the default stdinc++ path
      * correctly right away, but at the moment whatever I wrote also works.
      */
-
+    if (NoStdInc) { push("-nostdinc++"); }
     // NOTE: The comment above was relevant when the custom standard
     // library was used in the build process. When the system-provided one
     // is used it does not seem to be required (on the contrary, removing
     // std include causes issues with `cstdddef`), but the message above
     // should stay there regardless.
 
-    // push("-nostdinc++");
 
     LOG_CERR() << "Filtered command line arguments\n";
     for (auto const& arg : filteredArgs) {

--- a/scripts/cxx_repository/CMakeLists.txt
+++ b/scripts/cxx_repository/CMakeLists.txt
@@ -14,9 +14,6 @@ set_target_flags(code_forensics)
 
 glob_add_sources2(code_forensics "${BASE}/scripts/cxx_repository/.*" "${BASE}")
 
-set(SQLCPP_DIR "${BASE}/thirdparty/SQLiteCpp")
-add_subdirectory("${SQLCPP_DIR}" "${CMAKE_BINARY_DIR}/sqlitecpp_build")
-
 SET(LIBGIT2_PREFIX "${CMAKE_BINARY_DIR}/libgit2")
 message(STATUS "LIBGIT2_PREFIX = ${LIBGIT2_PREFIX}")
 

--- a/scripts/cxx_repository/code_forensics.cpp
+++ b/scripts/cxx_repository/code_forensics.cpp
@@ -213,8 +213,7 @@ class LinePrinterLogSink : public absl::LogSink {
 };
 
 
-auto main(int argc, const char** argv) -> int {
-
+int main(int argc, char** argv) {
     auto config = UPtr<walker_config>(new walker_config{});
 
     {
@@ -332,9 +331,7 @@ auto main(int argc, const char** argv) -> int {
 
 
     fs::path db_file{config->cli.out.db_path};
-    if (fs::exists(db_file)) {
-        fs::remove(db_file);
-    }
+    if (fs::exists(db_file)) { fs::remove(db_file); }
 
     SQLite::Database db(
         db_file.native(), SQLite::OPEN_READWRITE | SQLite::OPEN_CREATE);

--- a/scripts/py_codegen/py_codegen/refl_extract.py
+++ b/scripts/py_codegen/py_codegen/refl_extract.py
@@ -256,6 +256,7 @@ def run_collector(
         f"--out={str(tmp_output)}",
         f"--toolchain-include={conf.toolchain_include}",
         f"--target-files={target_files}",
+        "--nostdinc",
         str(input),
     ]
 

--- a/src/cmake/functions_aux.cmake
+++ b/src/cmake/functions_aux.cmake
@@ -91,8 +91,6 @@ endfunction()
 
 function(glob_add_sources TARGET EXT_GLOB LS_REGEX)
   list_filter_files(SRC_FILES ${EXT_GLOB} "${LS_REGEX}")
-  message(STATUS "TARGET = ${TARGET} EXT_GLOB = ${EXT_GLOB} LS_REGEX = ${LS_REGEX}")
-  message(STATUS "SRC_FILES = ${SRC_FILES}")
   add_target_property("${TARGET}" SOURCES "${SRC_FILES}")
 endfunction()
 

--- a/src/cmake/functions_setup.cmake
+++ b/src/cmake/functions_setup.cmake
@@ -58,7 +58,7 @@ function(set_target_flags TARGET)
     # have to depend on the LD_PRELOAD_PATH being set up correctly.
     add_target_property(
       ${TARGET} LINK_OPTIONS
-      "-Wl,-rpath,${LLVM_GNU_CLANG_DIR},-rpath,${LLVM_STD_DIRS}")
+      "-Wl,-rpath,${LLVM_GNU_CLANG_DIR}")
 
     if(${ORG_USE_XRAY})
       add_target_property(${TARGET} COMPILE_OPTIONS "-fxray-instrument")

--- a/tests/python/refl/refl_test_driver.py
+++ b/tests/python/refl/refl_test_driver.py
@@ -134,7 +134,7 @@ def run_provider(
 
         base_dict = dict(
             input=[str(file) for file in text.keys()],
-            indexing_tool="{haxorg_root}/build/utils/reflection_tool/reflection_tool",
+            indexing_tool="{haxorg_root}/build/haxorg/scripts/cxx_codegen/reflection_tool/reflection_tool",
             compilation_database=compile_commands.name,
             toolchain_include="{haxorg_root}/toolchain/llvm/lib/clang/17/include",
             output_directory=str(code_dir),

--- a/tests/python/refl/test_libgit2_wrap.py
+++ b/tests/python/refl/test_libgit2_wrap.py
@@ -22,7 +22,7 @@ def test_libgit2_conv():
         root = get_haxorg_repo_root_path()
         start = dict(
             input=["{config_dir}/include"],
-            indexing_tool="{tool_dir}/build/utils_debug/reflection_tool",
+            indexing_tool="{tool_dir}/build/haxorg/scripts/cxx_codegen/reflection_tool",
             build_root="{config_dir}/build",
             source_root="{config_dir}",
             header_root="{config_dir}/include",

--- a/tests/python/repo/test_code_coverage.py
+++ b/tests/python/repo/test_code_coverage.py
@@ -19,7 +19,7 @@ from py_scriptutils.sqlalchemy_utils import (dump_db_all, dump_flat_table, forma
 from sqlalchemy import select
 
 profdata_merger = get_haxorg_repo_root_path().joinpath(
-    "build/utils/profdata_merger/profdata_merger")
+    "build/haxorg/scripts/cxx_codegen/profdata_merger/profdata_merger")
 
 tool_dir = get_haxorg_repo_root_path().joinpath("toolchain/llvm/bin")
 corpus_base = get_haxorg_repo_root_path().joinpath("tests/python/repo/coverage_corpus")

--- a/tests/specrunner/specrunner.cpp
+++ b/tests/specrunner/specrunner.cpp
@@ -24,6 +24,7 @@ void to_json(json& j, TestResult::Data const& data) {
 }
 } // namespace nlohmann
 
+
 int main(int argc, char** argv) {
     CHECK(argc == 2);
     json      json_spec = json::parse(std::string(argv[1]));


### PR DESCRIPTION
Merge two cmake  projects and use system-provided  standard library instead
of the one shipped with the LLVM.

- No more double builds for abseil and protobuf
- LLVM libraries  could not be  linked with  the LLVM standard  C++ library
  because of the string related ABI difference or something like that. 
- Qt cannot  be linked with the  LLVM standard library also  because of the
  string ABI differences.

More changes: run code generation as a part of local CI test. 
