### PR TITLE
API for generic access to the containers

### DIFF
--- a/invoke.yaml
+++ b/invoke.yaml
@@ -1,6 +1,5 @@
 quiet: false
 debug: true
-dryrun: true
 instrument:
   coverage: false
   xray: false

--- a/invoke.yaml
+++ b/invoke.yaml
@@ -1,5 +1,6 @@
 quiet: false
 debug: true
+forceall: true
 instrument:
   coverage: false
   xray: false

--- a/scripts/py_ci/py_ci/data_build.py
+++ b/scripts/py_ci/py_ci/data_build.py
@@ -383,18 +383,19 @@ def get_external_deps_list(
         configure_args=[opt("PYBIND11_TEST", False)],
     )
 
-    # utf8 = dep(
-    #     build_name="utf8_range",
-    #     deps_name="protobuf/third_party/utf8_range",
-    #     configure_args=[
-    #         opt("CMAKE_PREFIX_PATH", absl.get_install_prefix(install_dir=install_dir)),
-    #         opt("utf8_range_ENABLE_TESTS", False),
-    #         *ninja_build(),
-    #     ],
-    #     cmake_dirs=[
-    #         ("utf8_range", make_lib("utf8_range/{}/cmake/utf8_range")),
-    #     ],
-    # )
+    utf8 = dep(
+        build_name="utf8_range",
+        deps_name="protobuf/third_party/utf8_range",
+        configure_args=[
+            opt("CMAKE_PREFIX_PATH", absl.get_install_prefix(install_dir=install_dir)),
+            opt("utf8_range_ENABLE_TESTS", False),
+            opt("protobuf_VERSION", "6.31.1"),
+            *ninja_build(),
+        ],
+        cmake_dirs=[
+            ("utf8_range", make_lib("utf8_range/{}/cmake/utf8_range")),
+        ],
+    )
 
     dep(
         build_name="protobuf",
@@ -411,7 +412,7 @@ def get_external_deps_list(
             opt(
                 "CMAKE_PREFIX_PATH", ";".join([
                     absl.get_install_prefix(install_dir=install_dir),
-                    # utf8.get_install_prefix(install_dir=install_dir),
+                    utf8.get_install_prefix(install_dir=install_dir),
                 ])),
             opt("ABSL_CC_LIB_COPTS", "-fPIC"),
             opt("CMAKE_POSITION_INDEPENDENT_CODE", "TRUE"),

--- a/scripts/py_scriptutils/py_scriptutils/repo_files.py
+++ b/scripts/py_scriptutils/py_scriptutils/repo_files.py
@@ -53,9 +53,9 @@ class HaxorgConfig(BaseModel, extra="forbid"):
         description="Always execute task",
     )
 
-    forceall: bool = False
-    ci: bool = False
-    dryrun: bool = False
+    forceall: bool = Field(default=False)
+    ci: bool = Field(default=False)
+    dryrun: bool = Field(default=False)
 
     python_version: Optional[str] = None
     aggregate_filters: Optional[HaxorgCoverageAggregateFilter] = None

--- a/src/haxorg/sem/SemOrgCereal.cpp
+++ b/src/haxorg/sem/SemOrgCereal.cpp
@@ -626,29 +626,67 @@ struct pack<hstd::SmallVec<T, Size>>
     : pack_iterable_sequence<T, hstd::SmallVec<T, Size>> {};
 
 
-template <typename K, typename V>
-struct convert<immer::map<K, V>> {
+template <typename K, typename V, typename Container>
+struct convert_associative_container {
     msgpack::object const& operator()(
         msgpack::object const& o,
-        immer::map<K, V>&      v) const {
+        Container&             v) const {
         __trace_call();
-        expect_array<immer::map<K, V>>(o);
-        auto tmp = v.transient();
+        expect_array<Container>(o);
+        hstd::AssociativeContainerAdapter<Container> a{&v};
+
+        a.begin_insert();
+        a.clear();
+        a.reserve(o.via.array.size);
+
         for (uint32_t i = 0; i < o.via.array.size; ++i) {
             msgpack::object const& pair_obj = o.via.array.ptr[i];
-            expect_array<std::pair<K, V>>(pair_obj);
+            expect_array<Container>(pair_obj, 2);
+
             K key   = hstd::SerdeDefaultProvider<K>::get();
             V value = hstd::SerdeDefaultProvider<V>::get();
             pair_obj.via.array.ptr[0].convert(key);
             pair_obj.via.array.ptr[1].convert(value);
-            tmp.set(key, value);
+            a.insert_or_assign(std::move(key), std::move(value));
+        }
+        a.end_insert();
+        return o;
+    }
+};
+
+template <typename K, typename V, typename Container>
+struct pack_associative_container {
+    template <typename Stream>
+    packer<Stream>& operator()(
+        msgpack::packer<Stream>& o,
+        Container const&         v) const {
+        __trace_call();
+        o.pack_array(v.size());
+        hstd::AssociativeContainerAdapter<Container> a{&v};
+        if constexpr (requires(const K& a, const K& b) {
+                          { a < b } -> std::convertible_to<bool>;
+                      }) {
+            for (auto const& key : hstd::sorted(a.keys())) {
+                o.pack_array(2);
+                o.pack(key);
+                o.pack(a.at(key));
+            }
+        } else {
+            for (auto it = a.begin(); it != a.end(); ++it) {
+                o.pack_array(2);
+                o.pack(a.get_pair_key(*it));
+                o.pack(a.get_pair_value(*it));
+            }
         }
 
-        v = tmp.persistent();
 
         return o;
     }
 };
+
+template <typename K, typename V>
+struct convert<immer::map<K, V>>
+    : convert_associative_container<K, V, immer::map<K, V>> {};
 
 template <typename K, typename V>
 struct pack<immer::map<K, V>> {
@@ -685,82 +723,20 @@ struct pack<immer::map<K, V>> {
 
 
 template <typename K, typename V>
-struct convert<hstd::ext::ImmMap<K, V>> {
-    msgpack::object const& operator()(
-        msgpack::object const&   o,
-        hstd::ext::ImmMap<K, V>& v) const {
-        __trace_call();
-        o.convert<immer::map<K, V>>(v);
-        return o;
-    }
-};
+struct convert<hstd::ext::ImmMap<K, V>>
+    : convert_associative_container<K, V, hstd::ext::ImmMap<K, V>> {};
 
 template <typename K, typename V>
-struct pack<hstd::ext::ImmMap<K, V>> {
-    template <typename Stream>
-    packer<Stream>& operator()(
-        msgpack::packer<Stream>&       o,
-        hstd::ext::ImmMap<K, V> const& v) const {
-        __trace_call();
-        o.pack<immer::map<K, V>>(v);
-        return o;
-    }
-};
-
+struct pack<hstd::ext::ImmMap<K, V>>
+    : pack_associative_container<K, V, hstd::ext::ImmMap<K, V>> {};
 
 template <typename K, typename V>
-struct convert<hstd::UnorderedMap<K, V>> {
-    msgpack::object const& operator()(
-        msgpack::object const&    o,
-        hstd::UnorderedMap<K, V>& v) const {
-        __trace_call();
-        expect_array<hstd::UnorderedMap<K, V>>(o);
-
-        v.clear();
-        v.reserve(o.via.array.size);
-
-        for (uint32_t i = 0; i < o.via.array.size; ++i) {
-            msgpack::object const& pair_obj = o.via.array.ptr[i];
-            expect_array<hstd::UnorderedMap<K, V>>(pair_obj, 2);
-
-            K key   = hstd::SerdeDefaultProvider<K>::get();
-            V value = hstd::SerdeDefaultProvider<V>::get();
-            pair_obj.via.array.ptr[0].convert(key);
-            pair_obj.via.array.ptr[1].convert(value);
-            v.emplace(std::move(key), std::move(value));
-        }
-        return o;
-    }
-};
+struct convert<hstd::UnorderedMap<K, V>>
+    : convert_associative_container<K, V, hstd::UnorderedMap<K, V>> {};
 
 template <typename K, typename V>
-struct pack<hstd::UnorderedMap<K, V>> {
-    template <typename Stream>
-    packer<Stream>& operator()(
-        msgpack::packer<Stream>&        o,
-        hstd::UnorderedMap<K, V> const& v) const {
-        __trace_call();
-        o.pack_array(v.size());
-        if constexpr (requires(const K& a, const K& b) {
-                          { a < b } -> std::convertible_to<bool>;
-                      }) {
-            for (auto const& key : hstd::sorted(v.keys())) {
-                o.pack_array(2);
-                o.pack(key);
-                o.pack(v.at(key));
-            }
-        } else {
-            for (auto const& item : v) {
-                o.pack_array(2);
-                o.pack(item.first);
-                o.pack(item.second);
-            }
-        }
-
-
-        return o;
-    }
-};
+struct pack<hstd::UnorderedMap<K, V>>
+    : pack_associative_container<K, V, hstd::UnorderedMap<K, V>> {};
 
 
 template <>

--- a/src/hstd/CMakeLists.txt
+++ b/src/hstd/CMakeLists.txt
@@ -36,7 +36,7 @@ target_include_directories(hstd PUBLIC "$<BUILD_INTERFACE:${BASE}/thirdparty/imm
 if(${ORG_BUILD_TESTS} AND NOT ${ORG_EMCC_BUILD})
   haxorg_add_executable(tests_hstd)
   glob_add_sources2(TARGET tests_hstd LS_REGEX "${BASE}/tests/hstd/.*" SEARCH_BASE "${BASE}")
-  target_link_libraries(tests_hstd PUBLIC GTest::gtest hstd absl::flags absl::flags_parse)
+  target_link_libraries(tests_hstd PUBLIC GTest::gtest hstd absl::flags absl::flags_parse immer)
   add_test(NAME hstd_tests COMMAND tests_hstd)
 
   haxorg_add_executable(benchmark_hstd)

--- a/src/hstd/ext/immer.hpp
+++ b/src/hstd/ext/immer.hpp
@@ -87,11 +87,13 @@ struct SequentialImmerContainerAdapterBase
               Container,
               ValueType>;
 
-    container_type const*                                    container;
+    container_type const* container = nullptr;
     std::shared_ptr<typename container_type::transient_type> transient;
 
     SequentialImmerContainerAdapterBase(const container_type* container)
-        : container{container} {}
+        : container{container} {
+        hstd::logic_assertion_check_not_nil(container);
+    }
 
     auto begin_impl() const { return container->begin(); }
     auto end_impl() const { return container->end(); }
@@ -99,15 +101,15 @@ struct SequentialImmerContainerAdapterBase
     int size_impl() const { return static_cast<int>(container->size()); }
 
     void begin_insert_impl() {
-        transient = std::make_unique<
+        transient = std::make_shared<
             typename container_type::transient_type>(
             const_cast<container_type*>(container)->transient());
     }
 
     void end_insert_impl() {
         if (transient) {
-            *const_cast<container_type*>(container) = transient
-                                                          ->persistent();
+            *const_cast<container_type*>(container) = //
+                transient->persistent();
             transient.reset();
         }
     }

--- a/src/hstd/ext/immer.hpp
+++ b/src/hstd/ext/immer.hpp
@@ -280,6 +280,42 @@ struct AssociativeContainerAdapter<ext::ImmMap<K, V>>
     AssociativeContainerAdapter(const container_type* container)
         : SequentialContainerAdapter<ext::ImmMap<K, V>>{container} {}
 
+    bool contains_impl(pair_key_type const& key) const {
+        return this->container->find(key) != nullptr;
+    }
+
+    void insert_or_assign_impl(
+        pair_key_type const&   key,
+        pair_value_type const& value) {
+        if (this->transient) {
+            this->transient->set(key, value);
+        } else {
+            *const_cast<container_type*>(this->container) = //
+                const_cast<container_type*>(this->container)
+                    ->set(key, value);
+        }
+    }
+};
+
+template <typename K, typename V>
+struct AssociativeContainerAdapter<immer::map<K, V>>
+    : public AssociativeContainerAdapterBase<
+          AssociativeContainerAdapter<immer::map<K, V>>,
+          immer::map<K, V>,
+          K,
+          V>
+    , public SequentialContainerAdapter<immer::map<K, V>> {
+    using pair_key_type   = K;
+    using pair_value_type = V;
+    using container_type  = immer::map<K, V>;
+
+    AssociativeContainerAdapter(const container_type* container)
+        : SequentialContainerAdapter<immer::map<K, V>>{container} {}
+
+    bool contains_impl(pair_key_type const& key) const {
+        return this->container->find(key) != nullptr;
+    }
+
     void insert_or_assign_impl(
         pair_key_type const&   key,
         pair_value_type const& value) {

--- a/src/hstd/ext/immer.hpp
+++ b/src/hstd/ext/immer.hpp
@@ -90,6 +90,8 @@ struct SequentialImmerContainerAdapterBase
     container_type const* container = nullptr;
     std::shared_ptr<typename container_type::transient_type> transient;
 
+    void reserve_impl(int size) {}
+
     SequentialImmerContainerAdapterBase(const container_type* container)
         : container{container} {
         hstd::logic_assertion_check_not_nil(container);

--- a/src/hstd/ext/immer.hpp
+++ b/src/hstd/ext/immer.hpp
@@ -284,6 +284,10 @@ struct AssociativeContainerAdapter<ext::ImmMap<K, V>>
         return this->container->find(key) != nullptr;
     }
 
+    V const& at_impl(K const& key) const {
+        return this->container->at(key);
+    }
+
     void insert_or_assign_impl(
         pair_key_type const&   key,
         pair_value_type const& value) {
@@ -311,6 +315,10 @@ struct AssociativeContainerAdapter<immer::map<K, V>>
 
     AssociativeContainerAdapter(const container_type* container)
         : SequentialContainerAdapter<immer::map<K, V>>{container} {}
+
+    V const& at_impl(K const& key) const {
+        return this->container->at(key);
+    }
 
     bool contains_impl(pair_key_type const& key) const {
         return this->container->find(key) != nullptr;

--- a/src/hstd/ext/immer.hpp
+++ b/src/hstd/ext/immer.hpp
@@ -1,14 +1,19 @@
 #pragma once
 
 #include <immer/vector.hpp>
+#include <immer/vector_transient.hpp>
 #include <immer/box.hpp>
 #include <immer/map.hpp>
+#include <immer/map_transient.hpp>
 #include <immer/set.hpp>
+#include <immer/set_transient.hpp>
 #include <immer/flex_vector.hpp>
+#include <immer/flex_vector_transient.hpp>
 #include <hstd/stdlib/Json.hpp>
 #include <hstd/stdlib/reflection_visitor.hpp>
 #include <haxorg/sem/SemOrgTypes.hpp>
 #include <hstd/stdlib/Array.hpp>
+#include <hstd/stdlib/ContainerAPI.hpp>
 
 
 namespace hstd::ext {
@@ -65,3 +70,227 @@ struct ImmMap : immer::map<K, V> {
 template <typename T>
 using ImmSet = immer::set<T>;
 } // namespace hstd::ext
+
+
+namespace hstd {
+template <typename Derived, typename Container, typename ValueType>
+struct SequentialImmerContainerAdapterBase
+    : public SequentialContainerAdapterBase<
+          Derived,
+          Container,
+          ValueType> {
+
+    using container_type  = Container;
+    using item_value_type = ValueType;
+    using base_type       = SequentialContainerAdapterBase<
+              Derived,
+              Container,
+              ValueType>;
+
+    container_type const*                                    container;
+    std::shared_ptr<typename container_type::transient_type> transient;
+
+    SequentialImmerContainerAdapterBase(const container_type* container)
+        : container{container} {}
+
+    auto begin_impl() const { return container->begin(); }
+    auto end_impl() const { return container->end(); }
+
+    int size_impl() const { return static_cast<int>(container->size()); }
+
+    void begin_insert_impl() {
+        transient = std::make_unique<
+            typename container_type::transient_type>(
+            const_cast<container_type*>(container)->transient());
+    }
+
+    void end_insert_impl() {
+        if (transient) {
+            *const_cast<container_type*>(container) = transient
+                                                          ->persistent();
+            transient.reset();
+        }
+    }
+
+    void clear_impl() {
+        *const_cast<container_type*>(container) = container_type{};
+    }
+
+    template <typename F1, typename F2>
+    void add_with_transient(
+        const item_value_type& value,
+        F1&&                   transient_op,
+        F2&&                   persistent_op) {
+        if (transient) {
+            transient_op(transient.get(), value);
+        } else {
+            *const_cast<container_type*>(container) = persistent_op(
+                std::move(*const_cast<container_type*>(container)), value);
+        }
+    }
+};
+
+template <typename T>
+struct SequentialContainerAdapter<immer::set<T>>
+    : public SequentialImmerContainerAdapterBase<
+          SequentialContainerAdapter<immer::set<T>>,
+          immer::set<T>,
+          T> {
+    using container_type  = immer::set<T>;
+    using item_value_type = T;
+    using base_type       = SequentialImmerContainerAdapterBase<
+              SequentialContainerAdapter<immer::set<T>>,
+              container_type,
+              item_value_type>;
+
+    SequentialContainerAdapter(const container_type* container)
+        : base_type{container} {}
+
+    void add_impl(const item_value_type& value) {
+        this->add_with_transient(
+            value,
+            [](auto* trans, const auto& val) { trans->insert(val); },
+            [](auto&& cont, const auto& val) {
+                return std::move(cont).insert(val);
+            });
+    }
+};
+
+template <typename T>
+struct SequentialContainerAdapter<immer::flex_vector<T>>
+    : public SequentialImmerContainerAdapterBase<
+          SequentialContainerAdapter<immer::flex_vector<T>>,
+          immer::flex_vector<T>,
+          T> {
+
+    using container_type  = immer::flex_vector<T>;
+    using item_value_type = T;
+    using base_type       = SequentialImmerContainerAdapterBase<
+              SequentialContainerAdapter<immer::flex_vector<T>>,
+              container_type,
+              item_value_type>;
+
+    SequentialContainerAdapter(const container_type* container)
+        : base_type{container} {}
+
+    void add_impl(const item_value_type& value) {
+        this->add_with_transient(
+            value,
+            [](auto* trans, const auto& val) { trans->push_back(val); },
+            [](auto&& cont, const auto& val) {
+                return std::move(cont).push_back(val);
+            });
+    }
+};
+
+template <typename T>
+struct SequentialContainerAdapter<immer::vector<T>>
+    : public SequentialImmerContainerAdapterBase<
+          SequentialContainerAdapter<immer::vector<T>>,
+          immer::vector<T>,
+          T> {
+    using container_type  = immer::vector<T>;
+    using item_value_type = T;
+    using base_type       = SequentialImmerContainerAdapterBase<
+              SequentialContainerAdapter<immer::vector<T>>,
+              container_type,
+              item_value_type>;
+
+    SequentialContainerAdapter(const container_type* container)
+        : base_type{container} {}
+
+    void add_impl(const item_value_type& value) {
+        this->add_with_transient(
+            value,
+            [](auto* trans, const auto& val) { trans->push_back(val); },
+            [](auto&& cont, const auto& val) {
+                return std::move(cont).push_back(val);
+            });
+    }
+};
+
+template <typename K, typename V>
+struct SequentialContainerAdapter<immer::map<K, V>>
+    : public SequentialImmerContainerAdapterBase<
+          SequentialContainerAdapter<immer::map<K, V>>,
+          immer::map<K, V>,
+          std::pair<K, V>> {
+    using container_type  = immer::map<K, V>;
+    using item_value_type = std::pair<K, V>;
+    using base_type       = SequentialImmerContainerAdapterBase<
+              SequentialContainerAdapter<immer::map<K, V>>,
+              container_type,
+              item_value_type>;
+
+    SequentialContainerAdapter(const container_type* container)
+        : base_type{container} {}
+
+    void add_impl(const item_value_type& value) {
+        this->add_with_transient(
+            value,
+            [](auto* trans, const auto& val) {
+                trans->set(val.first, val.second);
+            },
+            [](auto&& cont, const auto& val) {
+                return std::move(cont).set(val.first, val.second);
+            });
+    }
+};
+
+template <typename K, typename V>
+struct SequentialContainerAdapter<ext::ImmMap<K, V>>
+    : public SequentialImmerContainerAdapterBase<
+          SequentialContainerAdapter<ext::ImmMap<K, V>>,
+          ext::ImmMap<K, V>,
+          std::pair<K, V>> {
+    using container_type  = ext::ImmMap<K, V>;
+    using item_value_type = std::pair<K, V>;
+    using base_type       = SequentialImmerContainerAdapterBase<
+              SequentialContainerAdapter<ext::ImmMap<K, V>>,
+              container_type,
+              item_value_type>;
+
+    SequentialContainerAdapter(const container_type* container)
+        : base_type{container} {}
+
+    void add_impl(const item_value_type& value) {
+        this->add_with_transient(
+            value,
+            [](auto* trans, const auto& val) {
+                trans->set(val.first, val.second);
+            },
+            [](auto&& cont, const auto& val) {
+                return std::move(cont).set(val.first, val.second);
+            });
+    }
+};
+
+template <typename K, typename V>
+struct AssociativeContainerAdapter<ext::ImmMap<K, V>>
+    : public AssociativeContainerAdapterBase<
+          AssociativeContainerAdapter<ext::ImmMap<K, V>>,
+          ext::ImmMap<K, V>,
+          K,
+          V>
+    , public SequentialContainerAdapter<ext::ImmMap<K, V>> {
+    using pair_key_type   = K;
+    using pair_value_type = V;
+    using container_type  = ext::ImmMap<K, V>;
+
+    AssociativeContainerAdapter(const container_type* container)
+        : SequentialContainerAdapter<ext::ImmMap<K, V>>{container} {}
+
+    void insert_or_assign_impl(
+        pair_key_type const&   key,
+        pair_value_type const& value) {
+        if (this->transient) {
+            this->transient->set(key, value);
+        } else {
+            *const_cast<container_type*>(this->container) = //
+                const_cast<container_type*>(this->container)
+                    ->set(key, value);
+        }
+    }
+};
+
+} // namespace hstd

--- a/src/hstd/stdlib/ContainerAPI.hpp
+++ b/src/hstd/stdlib/ContainerAPI.hpp
@@ -20,6 +20,7 @@ struct SequentialContainerAdapterBase : CRTP_this_method<Derived> {
     void begin_insert() { _this()->begin_insert_impl(); }
     void end_insert() { _this()->end_insert_impl(); }
     void clear() { _this()->clear_impl(); }
+    void reserve(int size) { _this()->reserve_impl(size); }
 };
 
 template <
@@ -45,6 +46,11 @@ struct AssociativeContainerAdapterBase : CRTP_this_method<Derived> {
     KeyType const& get_pair_key(
         std::pair<KeyType, ValueType> const& pair) const {
         return pair.first;
+    }
+
+    ValueType const& get_pair_value(
+        std::pair<KeyType, ValueType> const& pair) const {
+        return pair.second;
     }
 
     Vec<KeyType> keys() const {

--- a/src/hstd/stdlib/ContainerAPI.hpp
+++ b/src/hstd/stdlib/ContainerAPI.hpp
@@ -1,4 +1,6 @@
 #pragma once
+
+#include <hstd/system/aux_templates.hpp>
 #include <hstd/system/aux_utils.hpp>
 
 namespace hstd {
@@ -26,12 +28,12 @@ template <
 struct AssociativeContainerAdapterBase : CRTP_this_method<Derived> {
     using CRTP_this_method<Derived>::_this;
 
-    auto insert_or_assign(KeyType const& key, ValueType const& value) {
+    void insert_or_assign(KeyType const& key, ValueType const& value) {
         _this()->insert_or_assign_impl(key, value);
     }
 
     bool contains(KeyType const& key) const {
-        _this()->contains_impl(key);
+        return _this()->contains_impl(key);
     }
 };
 
@@ -44,12 +46,13 @@ class AssociativeContainerAdapter {};
 
 template <typename T>
 concept HasSequentialContainerAdapter = requires {
-    typename SequentialContainerAdapter<T>;
-    requires std::is_base_of_v<
-        SequentialContainerAdapterBase<
-            SequentialContainerAdapter<T>,
-            typename SequentialContainerAdapter<T>::container_type,
-            typename SequentialContainerAdapter<T>::item_value_type>,
-        SequentialContainerAdapter<T>>;
+    typename SequentialContainerAdapter<T>::item_value_type;
+};
+
+template <typename T>
+concept HasAssociativeContainerAdapter = requires {
+    typename AssociativeContainerAdapter<T>::item_value_type;
+    typename AssociativeContainerAdapter<T>::pair_key_type;
+    typename AssociativeContainerAdapter<T>::pair_value_type;
 };
 } // namespace hstd

--- a/src/hstd/stdlib/ContainerAPI.hpp
+++ b/src/hstd/stdlib/ContainerAPI.hpp
@@ -1,0 +1,55 @@
+#pragma once
+#include <hstd/system/aux_utils.hpp>
+
+namespace hstd {
+template <typename Derived, typename Container, typename ValueType>
+struct SequentialContainerAdapterBase : CRTP_this_method<Derived> {
+    using container_type = Container;
+    using value_type     = ValueType;
+
+    using CRTP_this_method<Derived>::_this;
+
+    auto begin() const { return _this()->begin_impl(); }
+    auto end() const { return _this()->end_impl(); }
+    int  size() const { return _this()->size_impl(); }
+    void add(const value_type& value) { _this()->add_impl(value); }
+    void begin_insert() { _this()->begin_insert_impl(); }
+    void end_insert() { _this()->end_insert_impl(); }
+    void clear() { _this()->clear_impl(); }
+};
+
+template <
+    typename Derived,
+    typename Container,
+    typename KeyType,
+    typename ValueType>
+struct AssociativeContainerAdapterBase : CRTP_this_method<Derived> {
+    using CRTP_this_method<Derived>::_this;
+
+    auto insert_or_assign(KeyType const& key, ValueType const& value) {
+        _this()->insert_or_assign_impl(key, value);
+    }
+
+    bool contains(KeyType const& key) const {
+        _this()->contains_impl(key);
+    }
+};
+
+template <typename T>
+class SequentialContainerAdapter {};
+
+template <typename T>
+class AssociativeContainerAdapter {};
+
+
+template <typename T>
+concept HasSequentialContainerAdapter = requires {
+    typename SequentialContainerAdapter<T>;
+    requires std::is_base_of_v<
+        SequentialContainerAdapterBase<
+            SequentialContainerAdapter<T>,
+            typename SequentialContainerAdapter<T>::container_type,
+            typename SequentialContainerAdapter<T>::item_value_type>,
+        SequentialContainerAdapter<T>>;
+};
+} // namespace hstd

--- a/src/hstd/stdlib/ContainerAPI.hpp
+++ b/src/hstd/stdlib/ContainerAPI.hpp
@@ -16,6 +16,7 @@ struct SequentialContainerAdapterBase : CRTP_this_method<Derived> {
     auto end() const { return _this()->end_impl(); }
     int  size() const { return _this()->size_impl(); }
     void add(const value_type& value) { _this()->add_impl(value); }
+    void add(value_type&& value) { _this()->add_impl(value); }
     void begin_insert() { _this()->begin_insert_impl(); }
     void end_insert() { _this()->end_insert_impl(); }
     void clear() { _this()->clear_impl(); }
@@ -85,9 +86,39 @@ class SequentialContainerAdapter<hstd::Vec<T>>
     using container_type  = hstd::Vec<T>;
     using item_value_type = T;
 
-    container_type const* container;
+    container_type const* container = nullptr;
 
-    SequentialContainerAdapter(const container_type* container) {}
+    SequentialContainerAdapter(const container_type* container)
+        : container{container} {}
+
+    auto begin_impl() const { return container->begin(); }
+    auto end_impl() const { return container->end(); }
+
+    void add_impl(const item_value_type& value) {
+        const_cast<container_type*>(container)->push_back(value);
+    }
+
+    int size_impl() const { return static_cast<int>(container->size()); }
+
+    void begin_insert_impl() {}
+    void end_insert_impl() {}
+    void clear_impl() { const_cast<container_type*>(container)->clear(); }
+};
+
+template <typename T, int Size>
+class SequentialContainerAdapter<hstd::SmallVec<T, Size>>
+    : public SequentialContainerAdapterBase<
+          SequentialContainerAdapter<hstd::SmallVec<T, Size>>,
+          hstd::SmallVec<T, Size>,
+          T> {
+  public:
+    using container_type  = hstd::SmallVec<T, Size>;
+    using item_value_type = T;
+
+    container_type const* container = nullptr;
+
+    SequentialContainerAdapter(const container_type* container)
+        : container{container} {}
 
     auto begin_impl() const { return container->begin(); }
     auto end_impl() const { return container->end(); }

--- a/src/hstd/stdlib/Debug.hpp
+++ b/src/hstd/stdlib/Debug.hpp
@@ -3,6 +3,8 @@
 #include <hstd/system/string_convert.hpp>
 #include <hstd/stdlib/ColText.hpp>
 #include <boost/preprocessor.hpp>
+#include <hstd/system/exceptions.hpp>
+#include <hstd/system/basic_templates.hpp>
 
 #include <iostream>
 
@@ -40,3 +42,54 @@ void setMessageStream(std::ostream& stream);
 #define _dfmt_expr(...)                                                   \
     (__fmt_location() BOOST_PP_SEQ_FOR_EACH(                              \
         _dfmt_expr_impl, _, BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__)))
+
+namespace hstd {
+template <typename T>
+void logic_assertion_check_not_nil(
+    T const*    ptr,
+    int         line     = __builtin_LINE(),
+    char const* function = __builtin_FUNCTION(),
+    char const* file     = __builtin_FILE()) {
+    if (hstd::value_metadata<T const*>::isNil(ptr)) {
+        throw ::hstd::logic_assertion_error::init(
+            ::hstd::fmt(
+                "Expected non-nullptr value for type {}",
+                hstd::value_metadata<T>::typeName()),
+            line,
+            function,
+            file);
+    }
+}
+
+template <typename T>
+void logic_assertion_check_not_nil(std::unique_ptr<T> const& p) {
+    return logic_assertion_check_not_nil(p.get());
+}
+
+template <typename T>
+void logic_assertion_check_not_nil(std::shared_ptr<T> const& p) {
+    return logic_assertion_check_not_nil(p.get());
+}
+
+template <typename T>
+void logic_assertion_check_not_nil(std::weak_ptr<T> const& p) {
+    return logic_assertion_check_not_nil(p.lock().get());
+}
+
+template <typename T>
+void logic_assertion_check_not_nil(
+    T const&    ptr,
+    int         line     = __builtin_LINE(),
+    char const* function = __builtin_FUNCTION(),
+    char const* file     = __builtin_FILE()) {
+    if (hstd::value_metadata<T>::isNil(ptr)) {
+        throw ::hstd::logic_assertion_error::init(
+            ::hstd::fmt(
+                "Expected non-nil value for type {}",
+                hstd::value_metadata<T>::typeName()),
+            line,
+            function,
+            file);
+    }
+}
+} // namespace hstd

--- a/src/hstd/stdlib/Map.hpp
+++ b/src/hstd/stdlib/Map.hpp
@@ -176,6 +176,7 @@ class SequentialKvPairContainerAdapter
     void clear_impl() { const_cast<container_type*>(container)->clear(); }
 };
 
+
 template <typename K, typename V>
 struct SequentialContainerAdapter<std::unordered_map<K, V>>
     : hstd::SequentialKvPairContainerAdapter<
@@ -201,6 +202,72 @@ struct SequentialContainerAdapter<hstd::SortedMap<K, V, _Compare>>
           K,
           V,
           hstd::SortedMap<K, V, _Compare>> {};
+
+
+template <typename K, typename V, typename Container>
+struct AssociativeKvPairContainerAdapter
+    : public AssociativeContainerAdapterBase<
+          AssociativeContainerAdapter<Container>,
+          Container,
+          K,
+          V>
+    , public SequentialContainerAdapter<Container> {
+    using pair_key_type   = K;
+    using pair_value_type = V;
+    using container_type  = Container;
+
+    AssociativeKvPairContainerAdapter(const container_type* container)
+        : SequentialContainerAdapter<Container>{container} {}
+
+    void insert_or_assign_impl(
+        pair_key_type const&   key,
+        pair_value_type const& value) {
+        const_cast<container_type*>(this->container)
+            ->insert_or_assign(key, value);
+    }
+
+    bool contains_impl(K const& key) const {
+        return this->container->contains(key);
+    }
+};
+
+template <typename K, typename V>
+struct AssociativeContainerAdapter<std::unordered_map<K, V>>
+    : hstd::AssociativeKvPairContainerAdapter<
+          K,
+          V,
+          std::unordered_map<K, V>> {
+    using pair_key_type   = K;
+    using pair_value_type = V;
+};
+
+template <typename K, typename V>
+struct AssociativeContainerAdapter<std::map<K, V>>
+    : hstd::AssociativeKvPairContainerAdapter<K, V, std::map<K, V>> {
+    using pair_key_type   = K;
+    using pair_value_type = V;
+};
+
+
+template <typename K, typename V>
+struct AssociativeContainerAdapter<hstd::UnorderedMap<K, V>>
+    : hstd::AssociativeKvPairContainerAdapter<
+          K,
+          V,
+          hstd::UnorderedMap<K, V>> {
+    using pair_key_type   = K;
+    using pair_value_type = V;
+};
+
+template <typename K, typename V, typename _Compare>
+struct AssociativeContainerAdapter<hstd::SortedMap<K, V, _Compare>>
+    : hstd::AssociativeKvPairContainerAdapter<
+          K,
+          V,
+          hstd::SortedMap<K, V, _Compare>> {
+    using pair_key_type   = K;
+    using pair_value_type = V;
+};
 
 template <typename K, typename V, typename Type>
 struct std_kv_tuple_iterator_hash {

--- a/src/hstd/stdlib/Map.hpp
+++ b/src/hstd/stdlib/Map.hpp
@@ -174,6 +174,9 @@ class SequentialKvPairContainerAdapter
     void begin_insert_impl() {}
     void end_insert_impl() {}
     void clear_impl() { const_cast<container_type*>(container)->clear(); }
+    void reserve_impl(int size) {
+        const_cast<container_type*>(container)->reserve(size);
+    }
 };
 
 

--- a/src/hstd/stdlib/Map.hpp
+++ b/src/hstd/stdlib/Map.hpp
@@ -216,6 +216,12 @@ struct AssociativeKvPairContainerAdapter
     using pair_value_type = V;
     using container_type  = Container;
 
+    using assoc_base = AssociativeContainerAdapterBase<
+        AssociativeContainerAdapter<Container>,
+        Container,
+        K,
+        V>;
+
     AssociativeKvPairContainerAdapter(const container_type* container)
         : SequentialContainerAdapter<Container>{container} {}
 
@@ -228,6 +234,10 @@ struct AssociativeKvPairContainerAdapter
 
     bool contains_impl(K const& key) const {
         return this->container->contains(key);
+    }
+
+    V const& at_impl(K const& key) const {
+        return this->container->at(key);
     }
 };
 

--- a/src/hstd/stdlib/Vec.hpp
+++ b/src/hstd/stdlib/Vec.hpp
@@ -8,7 +8,6 @@
 #    include <boost/container/small_vector.hpp>
 #endif
 #include <hstd/system/exceptions.hpp>
-#include <hstd/stdlib/ContainerAPI.hpp>
 
 
 #include <vector>
@@ -598,33 +597,6 @@ struct value_metadata<Vec<T>> {
     }
 };
 
-template <typename T>
-class SequentialContainerAdapter<hstd::Vec<T>>
-    : public SequentialContainerAdapterBase<
-          SequentialContainerAdapter<hstd::Vec<T>>,
-          hstd::Vec<T>,
-          T> {
-  public:
-    using container_type  = hstd::Vec<T>;
-    using item_value_type = T;
-
-    container_type const* container;
-
-    SequentialContainerAdapter(const container_type* container) {}
-
-    auto begin_impl() const { return container->begin(); }
-    auto end_impl() const { return container->end(); }
-
-    void add_impl(const item_value_type& value) {
-        const_cast<container_type*>(container)->push_back(value);
-    }
-
-    int size_impl() const { return static_cast<int>(container->size()); }
-
-    void begin_insert_impl() {}
-    void end_insert_impl() {}
-    void clear_impl() { const_cast<container_type*>(container)->clear(); }
-};
 
 
 } // namespace hstd

--- a/src/hstd/stdlib/Vec.hpp
+++ b/src/hstd/stdlib/Vec.hpp
@@ -8,6 +8,7 @@
 #    include <boost/container/small_vector.hpp>
 #endif
 #include <hstd/system/exceptions.hpp>
+#include <hstd/stdlib/ContainerAPI.hpp>
 
 
 #include <vector>
@@ -596,6 +597,35 @@ struct value_metadata<Vec<T>> {
              + std::string{">"};
     }
 };
+
+template <typename T>
+class SequentialContainerAdapter<hstd::Vec<T>>
+    : public SequentialContainerAdapterBase<
+          SequentialContainerAdapter<hstd::Vec<T>>,
+          hstd::Vec<T>,
+          T> {
+  public:
+    using container_type  = hstd::Vec<T>;
+    using item_value_type = T;
+
+    container_type const* container;
+
+    SequentialContainerAdapter(const container_type* container) {}
+
+    auto begin_impl() const { return container->begin(); }
+    auto end_impl() const { return container->end(); }
+
+    void add_impl(const item_value_type& value) {
+        const_cast<container_type*>(container)->push_back(value);
+    }
+
+    int size_impl() const { return static_cast<int>(container->size()); }
+
+    void begin_insert_impl() {}
+    void end_insert_impl() {}
+    void clear_impl() { const_cast<container_type*>(container)->clear(); }
+};
+
 
 } // namespace hstd
 

--- a/src/hstd/system/aux_templates.hpp
+++ b/src/hstd/system/aux_templates.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <hstd/system/basic_typedefs.hpp>
 #include <experimental/type_traits>
 
 namespace hstd {

--- a/tasks.py
+++ b/tasks.py
@@ -391,6 +391,7 @@ cmd:  {cmd}
                    (f" with [purple]{env}[/purple]" if env else ""))
 
     if conf.dryrun:
+        log(CAT).warning("Dry run, early exit")
         return (0, "", "")
 
     try:

--- a/tests/hstd/tContainerAPI.cpp
+++ b/tests/hstd/tContainerAPI.cpp
@@ -1,0 +1,107 @@
+#include <hstd/stdlib/Vec.hpp>
+#include <gtest/gtest.h>
+#include <hstd/ext/immer.hpp>
+#include <hstd/stdlib/Map.hpp>
+
+
+using namespace hstd;
+
+template <typename T>
+SequentialContainerAdapter<T> to_seq_adapter(T const* p) {
+    return SequentialContainerAdapter<T>(p);
+}
+
+template <HasSequentialContainerAdapter T>
+void sequential_api_user(
+    SequentialContainerAdapter<T>      a,
+    Vec<typename T::value_type> const& items) {
+    a.clear();
+    for (auto it = a.begin(); it != a.end(); ++it) {}
+    a.begin_insert();
+    for (auto const& it : items) { a.add(it); }
+    a.end_insert();
+}
+
+TEST(ContainerAdapterAPI, SequentialContainerAPI) {
+    {
+        Vec<int> v;
+        auto     a = to_seq_adapter(&v);
+        sequential_api_user(a, {1, 2});
+        EXPECT_EQ(a.size(), 2);
+    }
+    {
+        immer::vector<int> v;
+        auto               a = to_seq_adapter(&v);
+        sequential_api_user(a, {1, 2});
+        EXPECT_EQ(a.size(), 2);
+    }
+    {
+        immer::flex_vector<int> v;
+        auto                    a = to_seq_adapter(&v);
+        sequential_api_user(a, {1, 2});
+        EXPECT_EQ(a.size(), 2);
+    }
+    {
+        immer::map<int, int> v;
+        auto                 a = to_seq_adapter(&v);
+        sequential_api_user(a, {{1, 2}, {2, 3}});
+        EXPECT_EQ(a.size(), 2);
+    }
+    {
+        ext::ImmMap<int, int> v;
+        auto                  a = to_seq_adapter(&v);
+        sequential_api_user(a, {{1, 2}, {2, 3}});
+        EXPECT_EQ(a.size(), 2);
+    }
+    {
+        std::map<int, int> v;
+        auto               a = to_seq_adapter(&v);
+        sequential_api_user(a, {{1, 2}, {2, 3}});
+        EXPECT_EQ(a.size(), 2);
+    }
+    {
+        std::unordered_map<int, int> v;
+        auto                         a = to_seq_adapter(&v);
+        sequential_api_user(a, {{1, 2}, {2, 3}});
+        EXPECT_EQ(a.size(), 2);
+    }
+
+    {
+        hstd::SortedMap<int, int> v;
+        auto                      a = to_seq_adapter(&v);
+        sequential_api_user(a, {{1, 2}, {2, 3}});
+        EXPECT_EQ(a.size(), 2);
+    }
+    {
+        hstd::UnorderedMap<int, int> v;
+        auto                         a = to_seq_adapter(&v);
+        sequential_api_user(a, {{1, 2}, {2, 3}});
+        EXPECT_EQ(a.size(), 2);
+    }
+}
+
+
+template <typename T>
+void assoc_api_user(
+    SequentialContainerAdapter<T>      a,
+    Vec<typename T::value_type> const& items) {
+    sequential_api_user(a, items);
+}
+
+template <typename T>
+AssociativeContainerAdapter<T> to_assoc_adapter(T const* p) {
+    return AssociativeContainerAdapter<T>(p);
+}
+TEST(ContainerAdapterAPI, AssociativeContainerAPI) {
+    {
+        ext::ImmMap<int, int> v;
+        auto                  a = to_assoc_adapter(&v);
+        assoc_api_user(a, {{1, 2}, {2, 3}});
+        EXPECT_EQ(a.size(), 2);
+
+        a.begin_insert();
+        a.insert_or_assign(123, 3);
+        a.end_insert();
+        EXPECT_EQ(a.size(), 3);
+    }
+}

--- a/tests/hstd/tContainerAPI.cpp
+++ b/tests/hstd/tContainerAPI.cpp
@@ -101,4 +101,9 @@ TYPED_TEST(AssociativeContainerAdapterTest, AssociativeContainerAPI) {
     a.end_insert();
     EXPECT_EQ(a.size(), 3);
     EXPECT_TRUE(a.contains(123));
+
+    EXPECT_EQ(a.keys().size(), 3);
+    EXPECT_EQ(a.at(123), 3);
+    EXPECT_EQ(a.at(1), 2);
+    EXPECT_EQ(a.at(2), 3);
 }


### PR DESCRIPTION
Generalized API for reading and writing to sequential/associative containers -- adapter class makes it possible to work with immutable and mutable containers using the unified API, which is useful for serialization. 