### PR TITLE
Use fmt library instead of std::format

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -76,3 +76,6 @@
 [submodule "thirdparty/kiwi"]
 	path = thirdparty/kiwi
 	url = https://github.com/nucleic/kiwi.git
+[submodule "thirdparty/fmt"]
+	path = thirdparty/fmt
+	url = https://github.com/fmtlib/fmt.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,6 +304,7 @@ endif()
 
 find_package(Lager CONFIG REQUIRED)
 find_package(yaml-cpp CONFIG REQUIRED)
+find_package(fmt CONFIG REQUIRED)
 
 if(${ORG_BUILD_INTERNAL_TOOLS})
   find_package(SQLiteCpp CONFIG REQUIRED)

--- a/conanfile.py
+++ b/conanfile.py
@@ -49,7 +49,7 @@ class HaxorgConan(ConanFile):
             self.requires("immer/[>=0.8.1 <1]", **tr)
             self.requires("lager/[>=0.1.1 <1]", **tr)
             self.requires("nlohmann_json/[>=3.12.0 <4]", **tr)
-            self.requires("fmt/[>=12.1.0, <13]", **tr)
+            self.requires("fmt/[>=12.1.0 <13]", **tr)
 
             # self.requires("zstd/[>=1.5.7 <2]")
             # self.requires("openssl/[>=3.6.1 <4]")

--- a/conanfile.py
+++ b/conanfile.py
@@ -49,6 +49,7 @@ class HaxorgConan(ConanFile):
             self.requires("immer/[>=0.8.1 <1]", **tr)
             self.requires("lager/[>=0.1.1 <1]", **tr)
             self.requires("nlohmann_json/[>=3.12.0 <4]", **tr)
+            self.requires("fmt/[>=12.1.0, <13]", **tr)
 
             # self.requires("zstd/[>=1.5.7 <2]")
             # self.requires("openssl/[>=3.6.1 <4]")

--- a/scripts/cxx_codegen/main.cpp
+++ b/scripts/cxx_codegen/main.cpp
@@ -26,11 +26,11 @@ int main(int argc, char const** argv) {
     if (argc != 2) {
         std::vector<std::string> argv_v;
         for (int i = 0; i < argc; ++i) {
-            argv_v.push_back(std::format("\n '{}'", argv[i]));
+            argv_v.push_back(fmt::format("\n '{}'", argv[i]));
         }
 
         throw hstd::runtime_error::init(
-            std::format(
+            fmt::format(
                 "Expected exactly one CLI argument: JSON literal for the "
                 "configuration or a path to the JSON file. argc={} "
                 "argv={}",
@@ -43,7 +43,7 @@ int main(int argc, char const** argv) {
     if (std::string{argv[1]}.starts_with("/")) {
         if (!hstd::fs::exists(argv[1])) {
             throw std::logic_error(
-                std::format("Input configuration file '{}' does not exist", argv[1]));
+                fmt::format("Input configuration file '{}' does not exist", argv[1]));
         }
         json_parameters = hstd::readFile(argv[1]);
     } else {

--- a/scripts/cxx_codegen/profdata_merger.cpp
+++ b/scripts/cxx_codegen/profdata_merger.cpp
@@ -235,7 +235,7 @@ NO_COVERAGE static void loadInput(
         const llvm::StringRef FuncName = I.Name;
         bool                  Reported = false;
         Writer->addRecord(std::move(I), 1, [&](llvm::Error E) {
-            LOG(INFO) << std::format("{}", toString(std::move(E)));
+            LOG(INFO) << fmt::format("{}", toString(std::move(E)));
         });
     }
 
@@ -249,14 +249,14 @@ NO_COVERAGE static void loadInput(
 
     if (Reader->hasError()) {
         if (llvm::Error E = Reader->getError()) {
-            LOG(INFO) << std::format("{} {}", toString(std::move(E)), Filename);
+            LOG(INFO) << fmt::format("{} {}", toString(std::move(E)), Filename);
             return;
         }
     }
 
     std::vector<llvm::object::BuildID> BinaryIds;
     if (llvm::Error E = Reader->readBinaryIds(BinaryIds)) {
-        LOG(INFO) << std::format("{} {}", toString(std::move(E)), Filename);
+        LOG(INFO) << fmt::format("{} {}", toString(std::move(E)), Filename);
         return;
     }
 
@@ -326,7 +326,7 @@ namespace {
 NO_COVERAGE std::string SqlInsert(
     std::string const&              Table,
     std::vector<std::string> const& Columns) {
-    std::string result = std::format("INSERT INTO {} (", Table);
+    std::string result = fmt::format("INSERT INTO {} (", Table);
     for (auto it : llvm::enumerate(Columns)) {
         if (it.index() != 0) { result += ", "; }
         result += it.value();
@@ -529,7 +529,7 @@ struct db_build_ctx {
 
         for (auto const& r : llvm::enumerate(file_blacklist)) {
             if (r.value().match(path)) {
-                debug = std::format("blacklisted by #{}", r.index());
+                debug = fmt::format("blacklisted by #{}", r.index());
                 return false;
             }
         }
@@ -587,9 +587,9 @@ NO_COVERAGE int get_function_id(FunctionRecord const& f, queries& q, db_build_ct
 
 template <typename T, typename FormatContext>
 NO_COVERAGE auto fmt_ctx_field(
-    std::string const& field_name,
-    T const&           field_value,
-    FormatContext&     ctx) {
+    std::string const&   field_name,
+    T const&             field_value,
+    fmt::format_context& ctx) {
     fmt_ctx(" ", ctx);
     fmt_ctx(field_name, ctx);
     fmt_ctx(" = ", ctx);
@@ -597,9 +597,9 @@ NO_COVERAGE auto fmt_ctx_field(
 }
 
 template <>
-struct std::formatter<CountedRegion> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(CountedRegion const& p, FormatContext& ctx) const {
+struct fmt::formatter<CountedRegion> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(CountedRegion const& p, fmt::format_context& ctx) const {
         fmt_ctx("{", ctx);
         fmt_ctx_field("ExecutionCount", p.ExecutionCount, ctx);
         fmt_ctx_field("FalseExecutionCount", p.FalseExecutionCount, ctx);
@@ -615,9 +615,10 @@ struct std::formatter<CountedRegion> : std::formatter<std::string> {
 };
 
 template <>
-struct std::formatter<CoverageSegment> : std::formatter<std::string> {
-    template <typename FormatContext>
-    NO_COVERAGE auto format(CoverageSegment const& p, FormatContext& ctx) const {
+struct fmt::formatter<CoverageSegment> : fmt::formatter<std::string> {
+
+    NO_COVERAGE hstd::fmt_iter format(CoverageSegment const& p, fmt::format_context& ctx)
+        const {
         fmt_ctx("{", ctx);
         fmt_ctx_field("Line", p.Line, ctx);
         fmt_ctx_field("Col", p.Col, ctx);
@@ -776,7 +777,7 @@ NO_COVERAGE std::string format_range(T begin, T end) {
         } else {
             result += ", ";
         }
-        result += std::format("{}", *begin);
+        result += fmt::format("{}", *begin);
         ++begin;
     }
 
@@ -857,10 +858,10 @@ NO_COVERAGE std::shared_ptr<CoverageMapping> get_coverage_mapping(
     {
         __perf_trace("llvm", "Load raw profile coverage");
         loadInput(coverage_path, binary_path, &Writer);
-        LOG(INFO) << std::format("Loaded {} binary {}", coverage_path, binary_path);
+        LOG(INFO) << fmt::format("Loaded {} binary {}", coverage_path, binary_path);
     }
 
-    std::string tmp_path = std::format(
+    std::string tmp_path = fmt::format(
         "/tmp/{}.profdata",
         getMD5Digest(coverage_path, binary_path).digest().str().str());
 
@@ -873,12 +874,12 @@ NO_COVERAGE std::shared_ptr<CoverageMapping> get_coverage_mapping(
 
         if (EC) {
             throw hstd::domain_error::init(
-                std::format("Error while creating output stream {}", EC.message()));
+                fmt::format("Error while creating output stream {}", EC.message()));
         }
 
         if (llvm::Error E = Writer.write(Output)) {
             throw hstd::domain_error::init(
-                std::format("Failed write: {}", toString(std::move(E))));
+                fmt::format("Failed write: {}", toString(std::move(E))));
         }
     }
 
@@ -896,7 +897,7 @@ NO_COVERAGE std::shared_ptr<CoverageMapping> get_coverage_mapping(
 
         if (llvm::Error E = mapping_or_err.takeError()) {
             throw hstd::domain_error::init(
-                std::format(
+                fmt::format(
                     "Failed to load profdata {} from '{}'",
                     toString(std::move(E)),
                     tmp_path));
@@ -1086,20 +1087,20 @@ std::string generateInstantiateFunctionReport(BuildProfileCollection const& coll
         return totalDurB < totalDurA;
     });
 
-    auto formatDuration = [](int microseconds) -> std::string {
-        if (microseconds < 1000) { return std::format("{}µs", microseconds); }
+    hstd::fmt_iter formatDuration = [](int microseconds) -> std::string {
+        if (microseconds < 1000) { return fmt::format("{}µs", microseconds); }
         int ms          = microseconds / 1000;
         int remainingUs = microseconds % 1000;
         if (ms < 1000) {
-            if (remainingUs == 0) { return std::format("{}ms", ms); }
-            return std::format("{}ms {}µs", ms, remainingUs);
+            if (remainingUs == 0) { return fmt::format("{}ms", ms); }
+            return fmt::format("{}ms {}µs", ms, remainingUs);
         }
         int s           = ms / 1000;
         int remainingMs = ms % 1000;
-        if (remainingMs == 0 && remainingUs == 0) { return std::format("{}s", s); }
-        if (remainingUs == 0) { return std::format("{}s {}ms", s, remainingMs); }
-        if (remainingMs == 0) { return std::format("{}s {}µs", s, remainingUs); }
-        return std::format("{}s {}ms {}µs", s, remainingMs, remainingUs);
+        if (remainingMs == 0 && remainingUs == 0) { return fmt::format("{}s", s); }
+        if (remainingUs == 0) { return fmt::format("{}s {}ms", s, remainingMs); }
+        if (remainingMs == 0) { return fmt::format("{}s {}µs", s, remainingUs); }
+        return fmt::format("{}s {}ms {}µs", s, remainingMs, remainingUs);
     };
 
     std::string report;
@@ -1111,7 +1112,7 @@ std::string generateInstantiateFunctionReport(BuildProfileCollection const& coll
         int count  = static_cast<int>(events.size());
         int avgDur = totalDur / count;
 
-        report += std::format(
+        report += fmt::format(
             "{} = {} * {}: {}\n",
             formatDuration(totalDur),
             count,
@@ -1161,11 +1162,11 @@ NO_COVERAGE void build_run_coverage_merge(ReflectionCLI const& cli) {
 
     finally{flush_debug};
 
-    LOG(INFO) << std::format(
+    LOG(INFO) << fmt::format(
         "Using test summary file {}", cli.profdata.build_profile_dir);
 
     if (cli.profdata.debug_file) {
-        LOG(INFO) << std::format("Debug file enabled {}", cli.profdata.debug_file);
+        LOG(INFO) << fmt::format("Debug file enabled {}", cli.profdata.debug_file);
     }
 
     auto summary = JsonSerde<ProfdataFullProfile>::from_json(

--- a/scripts/cxx_codegen/profdata_merger.cpp
+++ b/scripts/cxx_codegen/profdata_merger.cpp
@@ -33,6 +33,7 @@
 
 #include <hstd/stdlib/OptFormatter.hpp>
 #include <hstd/stdlib/VariantSerde.hpp>
+#include <hstd/stdlib/MapFormatter.hpp>
 
 #include "reflection_demangler.hpp"
 #include "reflection_perf.hpp"
@@ -710,13 +711,13 @@ NO_COVERAGE void add_file_regions(
                         expanded_from_id = file_region_ids.at(id);
                     } else {
                         if (dbg) {
-                            LOG(INFO)
-                                << fmt("recursively adding region {} {} "
-                                       ".contains({}) -> {}",
-                                       id,
-                                       file_region_ids,
-                                       id,
-                                       file_region_ids.contains(id));
+                            LOG(INFO) << hstd::fmt(
+                                "recursively adding region {} {} "
+                                ".contains({}) -> {}",
+                                id,
+                                file_region_ids,
+                                id,
+                                file_region_ids.contains(id));
                         }
 
                         expanded_from_id = addRegion(id);
@@ -1090,7 +1091,7 @@ std::string generateInstantiateFunctionReport(BuildProfileCollection const& coll
         return totalDurB < totalDurA;
     });
 
-    hstd::fmt_iter formatDuration = [](int microseconds) -> std::string {
+    auto formatDuration = [](int microseconds) -> std::string {
         if (microseconds < 1000) { return fmt::format("{}µs", microseconds); }
         int ms          = microseconds / 1000;
         int remainingUs = microseconds % 1000;

--- a/scripts/cxx_codegen/profdata_merger.cpp
+++ b/scripts/cxx_codegen/profdata_merger.cpp
@@ -585,38 +585,39 @@ NO_COVERAGE int get_function_id(FunctionRecord const& f, queries& q, db_build_ct
 }
 
 
-template <typename T, typename FormatContext>
+template <typename T>
 NO_COVERAGE auto fmt_ctx_field(
     std::string const&   field_name,
     T const&             field_value,
     fmt::format_context& ctx) {
-    fmt_ctx(" ", ctx);
-    fmt_ctx(field_name, ctx);
-    fmt_ctx(" = ", ctx);
-    return fmt_ctx(field_value, ctx);
+    hstd::fmt_ctx(" ", ctx);
+    hstd::fmt_ctx(field_name, ctx);
+    hstd::fmt_ctx(" = ", ctx);
+    return hstd::fmt_ctx(field_value, ctx);
 }
 
 template <>
-struct fmt::formatter<CountedRegion> : fmt::formatter<std::string> {
-
+struct fmt::formatter<CountedRegion> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(CountedRegion const& p, fmt::format_context& ctx) const {
         fmt_ctx("{", ctx);
         fmt_ctx_field("ExecutionCount", p.ExecutionCount, ctx);
         fmt_ctx_field("FalseExecutionCount", p.FalseExecutionCount, ctx);
         fmt_ctx_field(
             "Loc",
-            fmt("[{}:{}..{}:{}]", p.LineStart, p.ColumnStart, p.LineEnd, p.ColumnEnd),
+            hstd::fmt(
+                "[{}:{}..{}:{}]", p.LineStart, p.ColumnStart, p.LineEnd, p.ColumnEnd),
             ctx);
         fmt_ctx_field("FileId", p.FileID, ctx);
         fmt_ctx_field("ExpandedFileID", p.ExpandedFileID, ctx);
         fmt_ctx_field("Kind", p.Kind, ctx);
-        return fmt_ctx("}", ctx);
+        return hstd::fmt_ctx("}", ctx);
     }
 };
 
 template <>
-struct fmt::formatter<CoverageSegment> : fmt::formatter<std::string> {
-
+struct fmt::formatter<CoverageSegment> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     NO_COVERAGE hstd::fmt_iter format(CoverageSegment const& p, fmt::format_context& ctx)
         const {
         fmt_ctx("{", ctx);
@@ -626,7 +627,7 @@ struct fmt::formatter<CoverageSegment> : fmt::formatter<std::string> {
         fmt_ctx_field("HasCount", p.HasCount, ctx);
         fmt_ctx_field("IsRegionEntry", p.IsRegionEntry, ctx);
         fmt_ctx_field("IsGapRegion", p.IsGapRegion, ctx);
-        return fmt_ctx(" }", ctx);
+        return hstd::fmt_ctx(" }", ctx);
     }
 };
 
@@ -747,7 +748,8 @@ NO_COVERAGE void add_file_regions(
             q.file_region.reset();
 
             if (dbg) {
-                LOG(INFO) << fmt("add region [{} -> {}] {} ", region_index, region_id, r);
+                LOG(INFO) << hstd::fmt(
+                    "add region [{} -> {}] {} ", region_index, region_id, r);
             }
 
             file_region_ids[region_index] = region_id;
@@ -760,7 +762,7 @@ NO_COVERAGE void add_file_regions(
                 addRegion(it.index());
             } else {
                 if (dbg) {
-                    LOG(INFO) << fmt("skip region [{}] {}", it.index(), it.value());
+                    LOG(INFO) << hstd::fmt("skip region [{}] {}", it.index(), it.value());
                 }
             }
         }
@@ -964,14 +966,14 @@ void process_runs(
 
 
     if (cli.profdata.coverage_mapping_dump) {
-        LOG(INFO) << fmt(
+        LOG(INFO) << hstd::fmt(
             "Coverage mapping dump to {}", cli.profdata.coverage_mapping_dump.value());
     }
 
     for (auto const& run : runs) {
         __perf_trace("main", "Insert run data");
         finally{flush_debug};
-        LOG(INFO) << fmt(
+        LOG(INFO) << hstd::fmt(
             "[{}/{}] Insert run data profile={} binary={}",
             run.index,
             full_run_size,
@@ -986,7 +988,8 @@ void process_runs(
 
         if (mapping.get() == nullptr) {
             throw std::logic_error(
-                fmt("Failed to load coverage mapping profile={} binary={}",
+                hstd::fmt(
+                    "Failed to load coverage mapping profile={} binary={}",
                     run.run.test_profile,
                     run.run.test_binary));
         }
@@ -995,9 +998,9 @@ void process_runs(
             auto j = to_json_eval(*mapping);
             auto path //
                 = fs::path{*cli.profdata.coverage_mapping_dump}
-                / fmt("coverage_mapping_{}.json", run.index);
+                / hstd::fmt("coverage_mapping_{}.json", run.index);
 
-            LOG(INFO) << fmt("coverage-mapping-dump={}", path);
+            LOG(INFO) << hstd::fmt("coverage-mapping-dump={}", path);
             writeFile(path, j.dump(2));
         }
 

--- a/scripts/cxx_codegen/reflection_collector.cpp
+++ b/scripts/cxx_codegen/reflection_collector.cpp
@@ -1,7 +1,6 @@
 #include "reflection_collector.hpp"
 
 #include <llvm/Support/TimeProfiler.h>
-#include <format>
 #include <absl/log/log.h>
 #include <absl/log/check.h>
 #include <google/protobuf/util/json_util.h>
@@ -315,7 +314,7 @@ std::string getAbsoluteDeclLocation(c::Decl const* Decl) {
 
 template <typename T>
 void add_debug(T* it, std::string const& msg, int line = __builtin_LINE()) {
-    it->mutable_dbgorigin()->append(std::format(" [{}]{}", line, msg));
+    it->mutable_dbgorigin()->append(fmt::format(" [{}]{}", line, msg));
 }
 
 template <typename T>
@@ -353,7 +352,7 @@ finally_std scope_debug(T* it, std::string const& pre, std::string const& post) 
 std::ostream& errs(
     int         line     = __builtin_LINE(),
     char const* function = __builtin_FUNCTION()) {
-    return std::cerr << std::format("[refl-lib] [{}:{}] ", function, line);
+    return std::cerr << fmt::format("[refl-lib] [{}:{}] ", function, line);
 }
 
 
@@ -404,7 +403,7 @@ std::string formatDeclLocation(clang::Decl const* Decl) {
         name = "(not named decl)";
     }
 
-    return std::format(
+    return fmt::format(
         "Decl '{}' of kind {} at '{}'",
         name,
         Decl->getDeclKindName(),
@@ -422,7 +421,7 @@ std::vector<QualType> ReflASTVisitor::getNamespaces(
         space->set_name(Namespace->getNameAsString());
         add_debug(
             space,
-            std::format("Namespace visitation of '{}'", Namespace->getNameAsString()));
+            fmt::format("Namespace visitation of '{}'", Namespace->getNameAsString()));
         space->set_isnamespace(true);
         assert(!space->name().empty());
     }
@@ -479,7 +478,7 @@ void ReflASTVisitor::applyNamespaces(
                                                            : *oldNamespaces.at(i);
 
             //            if (newSpace.name().empty()) {
-            //                llvm::outs() << std::format(
+            //                llvm::outs() << fmt::format(
             //                    "Empty namespace formatted from {}\n",
             //                    newSpace.dbgorigin());
             //            }
@@ -489,7 +488,7 @@ void ReflASTVisitor::applyNamespaces(
             space->set_isglobalnamespace(newSpace.isglobalnamespace());
             add_debug(
                 space,
-                std::format(
+                fmt::format(
                     "Apply namespace @[{}] from {}:{} '{}'",
                     i,
                     line,
@@ -537,14 +536,14 @@ std::vector<QualType> ReflASTVisitor::getNamespaces(
             if (!nns->isAnonymousNamespace() && !nns->isInlineNamespace()) {
                 auto space = &result.emplace_back();
                 add_debug(
-                    space, std::format("regular type namespaces @[{}]", namespaceIndex));
+                    space, fmt::format("regular type namespaces @[{}]", namespaceIndex));
                 space->set_name(nns->getNameAsString());
                 space->set_isnamespace(true);
                 ++namespaceIndex;
             }
         } else if (c::CXXRecordDecl* rec = dyn_cast<c::CXXRecordDecl>(dc)) {
             auto space = &result.emplace_back();
-            add_debug(space, std::format("type namespace @[{}]", namespaceIndex));
+            add_debug(space, fmt::format("type namespace @[{}]", namespaceIndex));
             space->set_name(rec->getNameAsString());
             space->set_isnamespace(false);
             ++namespaceIndex;
@@ -577,12 +576,12 @@ void ReflASTVisitor::log_visit(
             if (false) {
                 HSLOG_TRACE(
                     "{}",
-                    std::format(
+                    fmt::format(
                         "\n-----------------------------------------------"
                         "---\n{}\n---\n{}\n"
                         "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^"
                         "^",
-                        std::format("line:{} function:{} msg:{}", line, function, msg),
+                        fmt::format("line:{} function:{} msg:{}", line, function, msg),
                         (Decl ? "\n" + dump(Decl, 5) : "")));
             }
         } else {
@@ -837,13 +836,13 @@ void ReflASTVisitor::fillTypeRec(
             auto const name //
                 = In->getAs<c::RecordType>()->getDecl()->getNameAsString();
 
-            add_debug(Out, std::format(" >record '{}'", name));
+            add_debug(Out, fmt::format(" >record '{}'", name));
             Out->set_name(name);
         } else if (In->isEnumeralType()) {
             auto const name //
                 = In->getAs<c::EnumType>()->getDecl()->getNameAsString();
             applyNamespaces(Out, getNamespaces(In, Loc));
-            add_debug(Out, std::format(" >enum '{}'", name));
+            add_debug(Out, fmt::format(" >enum '{}'", name));
             Out->set_name(name);
 
         } else if (In->isFunctionProtoType()) {
@@ -867,7 +866,7 @@ void ReflASTVisitor::fillTypeRec(
                 fillExpr(expr_param->mutable_typevalue(), size, Loc);
             } else {
                 expr_param->mutable_typevalue()->set_value(
-                    std::format("{}", C_ARRT->getSize().getSExtValue()));
+                    fmt::format("{}", C_ARRT->getSize().getSExtValue()));
                 add_debug(expr_param, " >int value");
             }
         } else if (In->isArrayType()) {
@@ -888,7 +887,7 @@ void ReflASTVisitor::fillTypeRec(
             } else {
                 unsigned Depth = parm->getDepth();
                 unsigned Index = parm->getIndex();
-                Out->set_name(std::format("unnamed_{}_{}", Depth, Index));
+                Out->set_name(fmt::format("unnamed_{}_{}", Depth, Index));
             }
 
         } else if (
@@ -944,7 +943,7 @@ void ReflASTVisitor::fillTypeRec(
                 Loc);
 
         } else {
-            add_debug(Out, std::format("typeclass={}", In->getTypeClassName()));
+            add_debug(Out, fmt::format("typeclass={}", In->getTypeClassName()));
             Diag(
                 DiagKind::Warning, "Unhandled serialization for a type '%0' (%1 %2)", Loc)
                 << In << dump(In);
@@ -1054,7 +1053,7 @@ void ReflASTVisitor::fillFieldDecl(Record::Field* sub, c::FieldDecl const* field
 
     log_visit(
         field,
-        std::format(
+        fmt::format(
             "field_visit has_rec_type: {} name: {}",
             RecType != nullptr,
             field->getNameAsString()));
@@ -1066,7 +1065,7 @@ void ReflASTVisitor::fillFieldDecl(Record::Field* sub, c::FieldDecl const* field
     if (RecType && RecType->getDecl()) {
         log_visit(
             RecType->getDecl(),
-            std::format("Anon:{}", RecType->getDecl()->getNameAsString().empty()));
+            fmt::format("Anon:{}", RecType->getDecl()->getNameAsString().empty()));
     }
 
     if (RecType != nullptr && RecType->getDecl()
@@ -1443,7 +1442,7 @@ bool ReflASTVisitor::VisitCXXRecordDecl(c::CXXRecordDecl* Decl) {
     } else {
         log_visit(
             nullptr,
-            std::format(
+            fmt::format(
                 "declaration context is not translation unit '{}' at {}, "
                 "isRefl:{}",
                 Decl->getNameAsString(),

--- a/scripts/cxx_codegen/reflection_collector.hpp
+++ b/scripts/cxx_codegen/reflection_collector.hpp
@@ -81,7 +81,7 @@ class ReflASTVisitor : public clang::RecursiveASTVisitor<ReflASTVisitor> {
         std::optional<clang::SourceLocation> const& Loc      = std::nullopt,
         int                                         line     = __builtin_LINE(),
         char const*                                 function = __builtin_FUNCTION()) {
-        std::string message = std::format("from code {}:{}", function, line);
+        std::string message = fmt::format("from code {}:{}", function, line);
         auto&       D       = Ctx->getDiagnostics();
         if (Loc) {
             return D.Report(*Loc, D.getCustomDiagID(L, FormatString)) << message;

--- a/scripts/cxx_codegen/reflection_collector_frontend.cpp
+++ b/scripts/cxx_codegen/reflection_collector_frontend.cpp
@@ -178,7 +178,7 @@ void run_semantic_symbols_collection(ReflectionCLI const& cli) {
         HSLOG_TRACE("Using compilation database {}", cli.reflection.compilation_database);
     } else {
         throw hstd::runtime_error::init(
-            std::format(
+            fmt::format(
                 "Failed to process provided JSON DB, failure was: {}\n"
                 "CompilationDB = {}",
                 ErrorMessage,
@@ -201,7 +201,7 @@ void run_semantic_symbols_collection(ReflectionCLI const& cli) {
         if (!hstd::fs::is_directory(
                 std::string(cli.reflection.toolchain_include.value()))) {
             throw hstd::FilesystemError::init(
-                std::format(
+                fmt::format(
                     "Toolchain include is not a directory or does not "
                     "exist "
                     "'{}'",

--- a/scripts/cxx_codegen/reflection_demangler.cpp
+++ b/scripts/cxx_codegen/reflection_demangler.cpp
@@ -908,7 +908,7 @@ BinaryFileDB getSymbolsInBinary(std::string const& path) {
     if (!binaryOrErr) {
         auto errorMsg = llvm::toString(binaryOrErr.takeError());
         throw hstd::runtime_error::init(
-            std::format("Binary loading error: {}", errorMsg));
+            fmt::format("Binary loading error: {}", errorMsg));
     }
 
     llvm::object::OwningBinary<llvm::object::Binary> binary = std::move(*binaryOrErr);
@@ -978,7 +978,7 @@ namespace {
 NO_COVERAGE std::string SqlInsert(
     std::string const&              Table,
     std::vector<std::string> const& Columns) {
-    std::string result = std::format("INSERT INTO {} (", Table);
+    std::string result = fmt::format("INSERT INTO {} (", Table);
     for (auto it : llvm::enumerate(Columns)) {
         if (it.index() != 0) { result += ", "; }
         result += it.value();
@@ -1143,7 +1143,7 @@ NO_COVERAGE void run_binary_symbols_collection(ReflectionCLI const& cli) {
     __perf_trace("main", "Process binary symbols");
     if (cli.output.empty()) {
         throw std::invalid_argument(
-            std::format("Missing output path for reflection run"));
+            fmt::format("Missing output path for reflection run"));
     }
 
     auto db = getSymbolsInBinary(cli.input.at(0));

--- a/scripts/cxx_executor/execution_flow_tracker.cpp
+++ b/scripts/cxx_executor/execution_flow_tracker.cpp
@@ -30,6 +30,7 @@
 #include <hstd/stdlib/TraceBaseStructuredLog.hpp>
 #include <hstd/stdlib/VariantSerde.hpp>
 #include <hstd/stdlib/Vec.hpp>
+#include <hstd/stdlib/VecFormatter.hpp>
 
 using namespace hstd;
 using namespace hstd::log::record;

--- a/scripts/cxx_repository/code_forensics.cpp
+++ b/scripts/cxx_repository/code_forensics.cpp
@@ -19,6 +19,7 @@
 #include <hstd/ext/logger.hpp>
 #include <hstd/stdlib/SetSerde.hpp>
 #include <hstd/stdlib/JsonCLIParser.hpp>
+#include <hstd/stdlib/VecFormatter.hpp>
 
 #include "repo_profile.hpp"
 

--- a/scripts/cxx_repository/code_forensics.cpp
+++ b/scripts/cxx_repository/code_forensics.cpp
@@ -242,7 +242,7 @@ int main(int argc, char** argv) {
     git_libgit2_init();
     // Check whether threads can be enabled
     assert(git_libgit2_features() & GIT_FEATURE_THREADS);
-    std::string heads = fmt(".git/refs/heads/{}", config->cli.repo.branch);
+    std::string heads = hstd::fmt(".git/refs/heads/{}", config->cli.repo.branch);
 
     auto heads_path = config->repo_path() / heads;
     if (!fs::is_directory(config->repo_path())) {

--- a/scripts/cxx_repository/git_interface.hpp
+++ b/scripts/cxx_repository/git_interface.hpp
@@ -43,10 +43,10 @@ inline hstd::Str oid_tostr(git_oid oid) {
 }
 
 template <>
-struct std::formatter<git_oid> : std::formatter<std::string> {
-    template <typename FormatContext>
-    FormatContext::iterator format(git_oid const& p, FormatContext& ctx) const {
-        return std::formatter<std::string>{}.format(oid_tostr(p), ctx);
+struct fmt::formatter<git_oid> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(git_oid const& p, fmt::format_context& ctx) const {
+        return fmt::formatter<std::string>{}.format(oid_tostr(p), ctx);
     }
 };
 

--- a/scripts/cxx_repository/git_interface.hpp
+++ b/scripts/cxx_repository/git_interface.hpp
@@ -43,8 +43,8 @@ inline hstd::Str oid_tostr(git_oid oid) {
 }
 
 template <>
-struct fmt::formatter<git_oid> : fmt::formatter<std::string> {
-
+struct fmt::formatter<git_oid> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(git_oid const& p, fmt::format_context& ctx) const {
         return fmt::formatter<std::string>{}.format(oid_tostr(p), ctx);
     }

--- a/scripts/cxx_repository/git_interface.hpp
+++ b/scripts/cxx_repository/git_interface.hpp
@@ -46,7 +46,7 @@ template <>
 struct fmt::formatter<git_oid> {
     constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(git_oid const& p, fmt::format_context& ctx) const {
-        return fmt::formatter<std::string>{}.format(oid_tostr(p), ctx);
+        return hstd::fmt_ctx(oid_tostr(p), ctx);
     }
 };
 

--- a/scripts/cxx_repository/program_state.hpp
+++ b/scripts/cxx_repository/program_state.hpp
@@ -17,6 +17,7 @@
 #include "git_ir.hpp"
 #include "hstd/stdlib/Set.hpp"
 #include <hstd/system/reflection.hpp>
+#include <hstd/stdlib/VecFormatter.hpp>
 
 using Date         = boost::gregorian::date;
 using PTime        = boost::posix_time::ptime;
@@ -25,16 +26,16 @@ namespace stime    = std::chrono;
 namespace bd       = boost::describe;
 
 template <>
-struct fmt::formatter<Date> : fmt::formatter<std::string> {
-
+struct fmt::formatter<Date> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(Date const& p, fmt::format_context& ctx) const {
         return hstd::fmt_ctx(boost::gregorian::to_iso_extended_string(p), ctx);
     }
 };
 
 template <>
-struct fmt::formatter<PTime> : fmt::formatter<std::string> {
-
+struct fmt::formatter<PTime> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(PTime const& p, fmt::format_context& ctx) const {
         return hstd::fmt_ctx(boost::posix_time::to_iso_extended_string(p), ctx);
     }
@@ -202,7 +203,7 @@ struct walker_state {
                         os << "File\n";
                         had_file = true;
                     }
-                    os << fmt(
+                    os << hstd::fmt(
                         "  Section [{}] = {} at {} +{} -{}\n",
                         section_id,
                         escape_literal(content->at(content->at(section.path).path).text),

--- a/scripts/cxx_repository/program_state.hpp
+++ b/scripts/cxx_repository/program_state.hpp
@@ -25,18 +25,18 @@ namespace stime    = std::chrono;
 namespace bd       = boost::describe;
 
 template <>
-struct std::formatter<Date> : std::formatter<std::string> {
-    template <typename FormatContext>
-    FormatContext::iterator format(Date const& p, FormatContext& ctx) const {
-        return fmt_ctx(boost::gregorian::to_iso_extended_string(p), ctx);
+struct fmt::formatter<Date> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(Date const& p, fmt::format_context& ctx) const {
+        return hstd::fmt_ctx(boost::gregorian::to_iso_extended_string(p), ctx);
     }
 };
 
 template <>
-struct std::formatter<PTime> : std::formatter<std::string> {
-    template <typename FormatContext>
-    FormatContext::iterator format(PTime const& p, FormatContext& ctx) const {
-        return fmt_ctx(boost::posix_time::to_iso_extended_string(p), ctx);
+struct fmt::formatter<PTime> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(PTime const& p, fmt::format_context& ctx) const {
+        return hstd::fmt_ctx(boost::posix_time::to_iso_extended_string(p), ctx);
     }
 };
 

--- a/scripts/cxx_repository/repo_graph.cpp
+++ b/scripts/cxx_repository/repo_graph.cpp
@@ -53,7 +53,7 @@ hstd::SPtr<hstd::ext::graph::gv::GraphGroup> CommitGraph::toGraphviz() const {
 
         n //
             ->setColor(info.is_main ? "green" : "yellow")
-            ->setLabel(fmt("{}", info.oid).substr(0, 8));
+            ->setLabel(hstd::fmt("{}", info.oid).substr(0, 8));
 
         nodes.insert_or_assign(v, n);
     }

--- a/scripts/cxx_repository/repo_processing.cpp
+++ b/scripts/cxx_repository/repo_processing.cpp
@@ -49,12 +49,12 @@ void open_walker(git_oid& oid, walker_state& state) {
 
     if ((head_fileptr = fopen(head_filepath.c_str(), "r")) == nullptr) {
         throw std::system_error{
-            std::error_code{}, fmt("Error opening {}", head_filepath)};
+            std::error_code{}, hstd::fmt("Error opening {}", head_filepath)};
     }
 
     if (fread(head_rev.data(), 40, 1, head_fileptr) != 1) {
         throw std::system_error{
-            std::error_code{}, fmt("Error reading from {}", head_filepath)};
+            std::error_code{}, hstd::fmt("Error reading from {}", head_filepath)};
         fclose(head_fileptr);
     }
 
@@ -488,7 +488,7 @@ struct ChangeIterationState {
                  + (state->at(section_id).lines //
                     | rv ::enumerate            //
                     | rv::transform([&](auto const& line) {
-                          return std::format(
+                          return fmt::format(
                               "[{:<4}] '{:<100}'",
                               line.first,
                               state->str(state->at(line.second).content));
@@ -709,7 +709,7 @@ void check_tree_entry_consistency(
 
     ir::FileTrackSection const& section = state->at(section_id);
 
-    std::string where = std::format(
+    std::string where = fmt::format(
         "section:{} track:{} file-path:\"{}\" "
         "section-path:{} track:{} section-index:{}",
         section_id,
@@ -735,7 +735,7 @@ void check_tree_entry_consistency(
                     line_pair.second.second ? *line_pair.second.second : "");
             })
         | rv::transform([](auto const& line_tuple) -> std::string {
-              return std::format(
+              return fmt::format(
                   "[{:<4}] [{}] '{:<100}' '{:<100}'",
                   std::get<0>(line_tuple),
                   std::get<1>(line_tuple) == std::get<2>(line_tuple) ? "ok" : "er",

--- a/scripts/py_ci/py_ci/data_build.py
+++ b/scripts/py_ci/py_ci/data_build.py
@@ -146,6 +146,13 @@ def get_external_deps_list(
     # present.
 
     dep(
+        build_name="fmt",
+        deps_name="fmt",
+        cmake_dirs=[("fmt", make_lib("fmt/lib/cmake/fmt"))],
+        configure_args=[],
+    )
+
+    dep(
         build_name="graphviz",
         deps_name="graphviz",
         cmake_dirs=[("graphviz", make_lib("graphviz/lib/cmake/graphviz"))],

--- a/scripts/py_ci/py_ci/util_scripting.py
+++ b/scripts/py_ci/py_ci/util_scripting.py
@@ -13,7 +13,7 @@ logger.setLevel(logging.DEBUG)
 
 
 def get_threading_count() -> int:
-    return int((os.cpu_count() or 6) * 0.9)
+    return int((os.cpu_count() or 6) * 0.8)
 
 
 def get_j_cap() -> List[str]:

--- a/src/app/log_viewer/main.cpp
+++ b/src/app/log_viewer/main.cpp
@@ -4,6 +4,7 @@
 #include "imgui_impl_opengl3.h"
 #include <GLFW/glfw3.h>
 #include <hstd/stdlib/Debug.hpp>
+#include <hstd/stdlib/VecFormatter.hpp>
 
 struct Conf {
     Str  file;

--- a/src/app/log_viewer/trace_log_viewer.cpp
+++ b/src/app/log_viewer/trace_log_viewer.cpp
@@ -150,9 +150,9 @@ CommonEventArgs const& TraceLogViewer::get_args(TraceEvent const& event) const {
 std::string TraceLogViewer::format_name(TraceEvent const& event) const {
     auto const& base = get_base(event);
     if (base.name) {
-        return std::format("{} [{}]", *base.name, format_event_kind(event));
+        return fmt::format("{} [{}]", *base.name, format_event_kind(event));
     } else {
-        return std::format("[{}]", format_event_kind(event));
+        return fmt::format("[{}]", format_event_kind(event));
     }
 }
 
@@ -168,7 +168,7 @@ std::string TraceLogViewer::format_message(TraceEvent const& event) const {
 
 std::string TraceLogViewer::format_source(TraceEvent const& event) const {
     auto const& args = get_args(event);
-    return std::format("{}:{} {}", args.file, args.line, args.function);
+    return fmt::format("{}:{} {}", args.file, args.line, args.function);
 }
 
 std::string TraceLogViewer::format_event_kind(TraceEvent const& event) const {
@@ -182,7 +182,7 @@ std::string TraceLogViewer::format_event_kind(TraceEvent const& event) const {
 }
 
 std::string TraceLogViewer::format_scope_offset(int nesting_level) const {
-    return std::format("{}", nesting_level);
+    return fmt::format("{}", nesting_level);
 }
 
 void TraceLogViewer::draw_event_row_recursive(EventId id) {
@@ -205,7 +205,7 @@ void TraceLogViewer::draw_event_row(
     bool*              open_state) {
 
     TraceEvent const& event = *record.event;
-    std::string const label = std::format("##event_row_{}", record.id);
+    std::string const label = fmt::format("##event_row_{}", record.id);
 
     ImGui::TableNextRow();
     ImGui::PushID(static_cast<int>(record.id));
@@ -284,9 +284,9 @@ void TraceLogViewer::draw_structured_value(
 
     if (label) {
         if (value.shortRepr) {
-            node_label = std::format("{}: {}", label, *value.shortRepr);
+            node_label = fmt::format("{}: {}", label, *value.shortRepr);
         } else {
-            node_label = std::format("{}", label);
+            node_label = fmt::format("{}", label);
         }
     } else if (value.shortRepr) {
         node_label = *value.shortRepr;
@@ -301,14 +301,14 @@ void TraceLogViewer::draw_structured_value(
             },
             [&](StructuredValue::Enum const& data) {
                 ImGui::TextUnformatted(
-                    std::format("{} = {} ({})", node_label, data.value, data.index)
+                    fmt::format("{} = {} ({})", node_label, data.value, data.index)
                         .c_str());
             },
             [&](StructuredValue::List const& data) {
                 if (ImGui::TreeNode(node_label.c_str())) {
                     for (int i = 0; i < data.values.size(); ++i) {
                         draw_structured_value(
-                            data.values[i], std::format("[{}]", i).c_str());
+                            data.values[i], fmt::format("[{}]", i).c_str());
                     }
                     ImGui::TreePop();
                 }
@@ -317,7 +317,7 @@ void TraceLogViewer::draw_structured_value(
                 if (ImGui::TreeNode(node_label.c_str())) {
                     for (int i = 0; i < data.pairs.size(); ++i) {
                         auto const& pair = data.pairs[i];
-                        if (ImGui::TreeNode(std::format("pair {}", i).c_str())) {
+                        if (ImGui::TreeNode(fmt::format("pair {}", i).c_str())) {
                             if (pair.key) { draw_structured_value(*pair.key, "key"); }
                             if (pair.value) {
                                 draw_structured_value(*pair.value, "value");
@@ -329,7 +329,7 @@ void TraceLogViewer::draw_structured_value(
                 }
             },
             [&](StructuredValue::Object const& data) {
-                std::string object_label = std::format("{} <{}>", node_label, data.type);
+                std::string object_label = fmt::format("{} <{}>", node_label, data.type);
                 if (ImGui::TreeNode(object_label.c_str())) {
                     for (auto const& field : data.fields) {
                         if (field.value) {
@@ -344,10 +344,10 @@ void TraceLogViewer::draw_structured_value(
 
 void TraceLogViewer::draw_variables_state(VariablesState const& variables) {
     if (ImGui::TreeNode(
-            std::format("variables ({})", variables.variables.size()).c_str())) {
+            fmt::format("variables ({})", variables.variables.size()).c_str())) {
         for (auto const& variable : variables.variables) {
             std::string label = variable.type
-                                  ? std::format("{}: {}", variable.name, *variable.type)
+                                  ? fmt::format("{}: {}", variable.name, *variable.type)
                                   : variable.name.toBase();
 
             draw_structured_value(variable.value, label.c_str());

--- a/src/app/org_imgui/gui_app/main.cpp
+++ b/src/app/org_imgui/gui_app/main.cpp
@@ -308,7 +308,7 @@ void outline_tree_loop(GLFWwindow* window, org::sem::SemId<org::sem::Org> node) 
             for (auto const& it : priorities) {
                 bool shown = outline_config.priorities.contains(it);
                 bool start = shown;
-                ImGui::Checkbox(fmt("Priority '{}'", it).c_str(), &shown);
+                ImGui::Checkbox(hstd::fmt("Priority '{}'", it).c_str(), &shown);
                 if (start != shown) {
                     if (shown) {
                         outline_config.priorities.incl(it);

--- a/src/app/org_imgui/gui_app/main.cpp
+++ b/src/app/org_imgui/gui_app/main.cpp
@@ -51,7 +51,7 @@ std::string FormatTimeDelta(long delta_seconds) {
     long delta   = delta_seconds / 60;
     long hours   = delta / 60;
     long minutes = delta % 60;
-    return std::format("{}:{:02}", hours, minutes);
+    return fmt::format("{}:{:02}", hours, minutes);
 }
 
 namespace {

--- a/src/app/org_imgui/gui_lib/dir_explorer.cpp
+++ b/src/app/org_imgui/gui_lib/dir_explorer.cpp
@@ -213,7 +213,7 @@ struct DirNode : public SharedPtrApi<DirNode> {
 };
 
 std::string format_event(inotify_event const& event) {
-    std::string description = std::format(
+    std::string description = fmt::format(
         "Watch Descriptor: {}, Mask: {}, Cookie: {}, Length: {}, Name: {}",
         event.wd,
         event.mask,

--- a/src/app/org_imgui/gui_lib/im_org_ui_common.cpp
+++ b/src/app/org_imgui/gui_lib/im_org_ui_common.cpp
@@ -6,6 +6,8 @@
 #include <haxorg/sem/SemOrgFormat.hpp>
 #include <hstd/stdlib/PtrsFormatter.hpp>
 #include <haxorg/imm/ImmOrgAdapter.hpp>
+#include <hstd/stdlib/MapFormatter.hpp>
+#include <hstd/stdlib/SetFormatter.hpp>
 
 using namespace hstd;
 

--- a/src/app/org_imgui/gui_lib/im_org_ui_common.cpp
+++ b/src/app/org_imgui/gui_lib/im_org_ui_common.cpp
@@ -85,12 +85,13 @@ Opt<EditableOrgText::Result> EditableOrgText::render(
     std::string const&    id) {
     auto __scope = IM_SCOPE_BEGIN(
         "Editable text",
-        fmt("size:{} editing:{} buffer:{}",
+        hstd::fmt(
+            "size:{} editing:{} buffer:{}",
             size,
             is_editing,
             escape_literal(edit_buffer)));
 
-    auto cell_prefix = fmt("{}", id);
+    auto cell_prefix = hstd::fmt("{}", id);
 
 
     if (edit == Mode::Multiline) {
@@ -101,12 +102,12 @@ Opt<EditableOrgText::Result> EditableOrgText::render(
         // edited.
         if (IM_FN_BEGIN(
                 BeginChild,
-                fmt("##{}_wrap", cell_prefix).c_str(),
+                hstd::fmt("##{}_wrap", cell_prefix).c_str(),
                 size,
                 ImGuiChildFlags_None,
                 ImGuiWindowFlags_NoScrollbar)) {
-            IM_FN_PRINT("Child", fmt("size:{}", size));
-            ImGui::PushID(fmt("##{}_view", cell_prefix).c_str());
+            IM_FN_PRINT("Child", hstd::fmt("size:{}", size));
+            ImGui::PushID(hstd::fmt("##{}_view", cell_prefix).c_str());
             IM_FN_STMT(TextWrapped, "%s", value.c_str());
             IM_FN_PRINT("Wrapped text", value);
             ImGui::PopID();
@@ -138,7 +139,7 @@ Opt<EditableOrgText::Result> EditableOrgText::render(
             } else {
                 ImGui::SameLine(0.0f, 0.0f);
                 ImGui::SetNextItemWidth(size.x);
-                ImGui::InputText(fmt("##{}_edit", id).c_str(), &edit_buffer);
+                ImGui::InputText(hstd::fmt("##{}_edit", id).c_str(), &edit_buffer);
                 return std::nullopt;
             }
 

--- a/src/app/org_imgui/gui_lib/im_org_ui_common.hpp
+++ b/src/app/org_imgui/gui_lib/im_org_ui_common.hpp
@@ -101,7 +101,7 @@ struct EditableOrgTextEntry {
 DECL_ID_TYPE_MASKED(___RootId, DocRootId, hstd::u64, 32);
 
 template <>
-struct std::formatter<org::imm::ImmAstVersion*>
+struct fmt::formatter<org::imm::ImmAstVersion*>
     : hstd::std_format_ptr_as_hex<org::imm::ImmAstVersion> {};
 
 struct EditableOrgDocGroup {

--- a/src/app/org_imgui/gui_lib/imgui_utils.cpp
+++ b/src/app/org_imgui/gui_lib/imgui_utils.cpp
@@ -119,21 +119,22 @@ SPtr<StbFontMetrics> StbFontMetrics::FromPath(
     result->fontSize = fontSize;
     std::ifstream fontFile{fontPath, std::ios::binary | std::ios::ate};
     if (!fontFile.is_open()) {
-        throw std::runtime_error(fmt("Failed to open font file {}", fontPath));
+        throw std::runtime_error(hstd::fmt("Failed to open font file {}", fontPath));
     }
 
     std::streamsize size = fontFile.tellg();
     fontFile.seekg(0, std::ios::beg);
     result->buffer.resize(size);
     if (!fontFile.read((char*)result->buffer.data(), size)) {
-        throw std::runtime_error(fmt("Failed to read font file {}", fontPath));
+        throw std::runtime_error(hstd::fmt("Failed to read font file {}", fontPath));
     }
 
     if (!stbtt_InitFont(
             &result->font,
             result->buffer.data(),
             stbtt_GetFontOffsetForIndex(result->buffer.data(), 0))) {
-        throw std::runtime_error(fmt("Failed to initialize font from file {}", fontPath));
+        throw std::runtime_error(
+            hstd::fmt("Failed to initialize font from file {}", fontPath));
     }
 
     result->scale = stbtt_ScaleForPixelHeight(&result->font, fontSize);
@@ -260,7 +261,7 @@ bool ImRenderTraceRecord::ImRenderExpr(
     if (TraceState) {
         auto rec        = ImRenderTraceRecord::init(function, line, file);
         rec.im_function = im_function;
-        rec.im_id       = fmt("Evaluated to {}", expr);
+        rec.im_id       = hstd::fmt("Evaluated to {}", expr);
         PushUnitRecord(rec);
         auto tmp = rec.to_org_log_record();
         tmp.source_scope_add("expr");
@@ -286,7 +287,7 @@ void ImRenderTraceRecord::ImRenderUnit(
 void ImRenderTraceRecord::WriteTrace(OperationsTracer& trace) {
     for (auto const& [idx, s] : enumerate(stack)) {
         auto os = trace.getStream();
-        os << fmt("[{}] -- ", idx);
+        os << hstd::fmt("[{}] -- ", idx);
         trace.endStream(os);
         s.WriteRecord(trace, idx + 1);
     }
@@ -296,16 +297,16 @@ void ImRenderTraceRecord::WriteRecord(OperationsTracer& trace, int level) const 
     auto os = trace.getStream();
 
     os.indent(level * 2);
-    os << fmt(
+    os << hstd::fmt(
         "{} at {}:{} to draw {}",
         im_function.value_or("<>"),
         file ? fs::path{file}.filename() : "",
         line,
         escape_for_write(im_id.value_or("?")));
 
-    if (cursor_screenpos) { os << fmt(" screen {}", cursor_screenpos.value()); }
+    if (cursor_screenpos) { os << hstd::fmt(" screen {}", cursor_screenpos.value()); }
 
-    if (cursor_winpos) { os << fmt(" win {}", cursor_winpos.value()); }
+    if (cursor_winpos) { os << hstd::fmt(" win {}", cursor_winpos.value()); }
 
     trace.endStream(os);
 

--- a/src/app/org_imgui/gui_lib/imgui_utils.hpp
+++ b/src/app/org_imgui/gui_lib/imgui_utils.hpp
@@ -78,8 +78,8 @@ BOOST_DESCRIBE_STRUCT(ImVec4, (), (x, y, z, w));
 BOOST_DESCRIBE_STRUCT(ImRect, (), (Min, Max));
 
 template <>
-struct fmt::formatter<ImVec2> : fmt::formatter<std::string> {
-
+struct fmt::formatter<ImVec2> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(ImVec2 const& p, fmt::format_context& ctx) const {
         hstd::fmt_ctx("(", ctx);
         hstd::fmt_ctx(p.x, ctx);

--- a/src/app/org_imgui/gui_lib/imgui_utils.hpp
+++ b/src/app/org_imgui/gui_lib/imgui_utils.hpp
@@ -78,9 +78,9 @@ BOOST_DESCRIBE_STRUCT(ImVec4, (), (x, y, z, w));
 BOOST_DESCRIBE_STRUCT(ImRect, (), (Min, Max));
 
 template <>
-struct std::formatter<ImVec2> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(ImVec2 const& p, FormatContext& ctx) const {
+struct fmt::formatter<ImVec2> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(ImVec2 const& p, fmt::format_context& ctx) const {
         hstd::fmt_ctx("(", ctx);
         hstd::fmt_ctx(p.x, ctx);
         hstd::fmt_ctx(", ", ctx);

--- a/src/app/org_imgui/gui_lib/sem_tree_render.cpp
+++ b/src/app/org_imgui/gui_lib/sem_tree_render.cpp
@@ -78,10 +78,10 @@ struct ExporterVisual : public Exporter<ExporterVisual, int> {
         auto __scope = trace_scope(trace(VK::VisitField).with_field(name));
         for (const auto& [idx, sub] : enumerate(org)) {
             if (LeafKinds.contains(sub->getKind())) {
-                ImGui::Text("%s", fmt("[{}]", idx).c_str());
+                ImGui::Text("%s", hstd::fmt("[{}]", idx).c_str());
                 ImGui::SameLine();
                 visit(i, sub);
-            } else if (ImOrgTree(fmt("[{}] {}", idx, sub->getKind()))) {
+            } else if (ImOrgTree(hstd::fmt("[{}] {}", idx, sub->getKind()))) {
                 visit(i, sub);
                 ImGui::TreePop();
             }

--- a/src/app/org_imgui/gui_test/im_test_common.cpp
+++ b/src/app/org_imgui/gui_test/im_test_common.cpp
@@ -29,11 +29,11 @@ ImGuiWindow* GetWindowByName(std::string const& name) {
 
 
 Str getDebugFile(ImGuiTest* t, Str const& suffix) {
-    auto res = fs::path{
-        fmt("/tmp/haxorg_tests/imgui/{}/{}/{}",
-            normalize(t->Category),
-            normalize(t->Name),
-            suffix)};
+    auto res = fs::path{hstd::fmt(
+        "/tmp/haxorg_tests/imgui/{}/{}/{}",
+        normalize(t->Category),
+        normalize(t->Name),
+        suffix)};
     if (!fs::is_directory(res.parent_path())) { createDirectory(res.parent_path()); }
 
     return res.native();

--- a/src/app/org_imgui/gui_test/im_test_common.hpp
+++ b/src/app/org_imgui/gui_test/im_test_common.hpp
@@ -225,7 +225,7 @@ inline PredicateResult not_has_substring(hstd::Str const& lhs, hstd::Str const& 
         res.ok = true;
     } else {
         res.ok          = false;
-        res.explanation = fmt(
+        res.explanation = hstd::fmt(
             "Found substring starting {} ({} ...)",
             idx,
             lhs.substr(idx, std::clamp<int>(idx + 20, lhs.length(), idx + 20)));

--- a/src/app/org_viewer/file_agenda_table.cpp
+++ b/src/app/org_viewer/file_agenda_table.cpp
@@ -200,13 +200,13 @@ QVariant OrgTreeModel::data(QModelIndex const& index, int role) const {
             }
             case TableColumns::COMPLETION: {
                 auto [a, b] = node->getRecursiveCompletion();
-                return QString::fromStdString(std::format("{}/{}", a, b));
+                return QString::fromStdString(fmt::format("{}/{}", a, b));
             }
             case TableColumns::CLOCKED: {
                 int sec     = node->getClockedSeconds();
                 int hours   = sec / (60 * 60);
                 int minutes = (sec / 60) % 60;
-                return QString::fromStdString(std::format("{}:{}", hours, minutes));
+                return QString::fromStdString(fmt::format("{}:{}", hours, minutes));
             }
         }
     } else if (

--- a/src/app/org_viewer/shared_org_logic.cpp
+++ b/src/app/org_viewer/shared_org_logic.cpp
@@ -52,7 +52,7 @@ hstd::Str OrgAgendaNode::getAgeDisplay() const {
     for (const auto& [unit_name, unit_seconds] : units) {
         if (unit_seconds <= seconds) {
             int count = seconds / unit_seconds;
-            parts.push_back(std::format("{}{}", count, unit_name));
+            parts.push_back(fmt::format("{}{}", count, unit_name));
             seconds %= unit_seconds;
             if (parts.size() == 2) { break; }
         }

--- a/src/haxorg/api/EvalContext.cpp
+++ b/src/haxorg/api/EvalContext.cpp
@@ -114,7 +114,7 @@ struct EvalContext {
 
     Opt<json> getTargetValue(imm::ImmId const& target_id, bool asFlatText) const {
         auto target = getContext()->adaptUnrooted(target_id);
-        EVAL_TRACE(fmt("Target node is {}", target));
+        EVAL_TRACE(hstd::fmt("Target node is {}", target));
         EVAL_SCOPE();
         Opt<json> result;
 
@@ -139,11 +139,11 @@ struct EvalContext {
                     json out_table = json::array();
                     for (auto const& row : t.rows) {
                         json out_row = json::array();
-                        EVAL_TRACE(fmt("Row {}", row));
+                        EVAL_TRACE(hstd::fmt("Row {}", row));
                         EVAL_SCOPE();
                         for (auto const& cell :
                              getContext()->adaptUnrooted(row).as<imm::ImmRow>()->cells) {
-                            EVAL_TRACE(fmt("Cell {}", cell));
+                            EVAL_TRACE(hstd::fmt("Cell {}", cell));
                             if (asFlatText) {
                                 out_row.push_back(
                                     getCleanText(getContext()->adaptUnrooted(cell)));
@@ -168,7 +168,7 @@ struct EvalContext {
                         auto value = getContext()
                                          ->adaptUnrooted(code.result.back())
                                          .as<imm::ImmBlockCodeEvalResult>();
-                        EVAL_TRACE(fmt("Target code block evaluated to {}", value));
+                        EVAL_TRACE(hstd::fmt("Target code block evaluated to {}", value));
                         // EVAL_TRACE()
                         result = getTargetValue(value->node, asFlatText);
                     }
@@ -180,7 +180,7 @@ struct EvalContext {
     }
 
     Opt<json> getAttrValue(sem::AttrValue const& attr) const {
-        EVAL_TRACE(fmt("Resolving attribute value to state {}", attr));
+        EVAL_TRACE(hstd::fmt("Resolving attribute value to state {}", attr));
         EVAL_SCOPE();
         Str  name = attr.getString();
         auto node = getTrack()->names.get(name);
@@ -213,13 +213,15 @@ struct EvalContext {
             res.block = adapter.as<imm::ImmBlockCode>();
         } else {
             auto command = adapter.as<imm::ImmCmdCall>();
-            EVAL_TRACE(fmt("Getting target code block for name '{}'", command->name));
+            EVAL_TRACE(
+                hstd::fmt("Getting target code block for name '{}'", command->name));
             res.callsiteVars       = command->callAttrs;
             res.callsiteHeaderArgs = command->insideHeaderAttrs;
             if (auto opt_block = getTrack()->names.get(command->name)) {
                 if (!opt_block->is(OrgSemKind::BlockCode)) {
                     EVAL_TRACE(
-                        fmt("Name '{}' does not refer to a code block", command->name));
+                        hstd::fmt(
+                            "Name '{}' does not refer to a code block", command->name));
                 }
 
                 auto paths = getContext()->getPathsFor(opt_block.value());
@@ -228,7 +230,8 @@ struct EvalContext {
                 res.block = getContext()->adapt(paths.front()).as<imm::ImmBlockCode>();
             } else {
                 EVAL_TRACE(
-                    fmt("Name '{}' does not refer to a known document "
+                    hstd::fmt(
+                        "Name '{}' does not refer to a known document "
                         "entry",
                         command->name));
             }
@@ -243,12 +246,12 @@ struct EvalContext {
         sem::OrgCodeEvalInput const&  in,
         OrgCodeEvalParameters const&  conf) {
         EVAL_SCOPE();
-        EVAL_TRACE(fmt("Parsing stdout"));
+        EVAL_TRACE(hstd::fmt("Parsing stdout"));
         std::string activeName = hstd::fmt("<{}-output-{}>", currentFile, evalCounter);
         auto        doc  = conf.parseContext->parseString(out.stdoutText, activeName);
         auto        stmt = sem::SemId<sem::StmtList>::New();
         for (auto const& node : doc) {
-            EVAL_TRACE(fmt("Result node {}", node->getKind()));
+            EVAL_TRACE(hstd::fmt("Result node {}", node->getKind()));
             stmt->subnodes.push_back(node);
         }
         ++evalCounter;
@@ -347,14 +350,14 @@ struct EvalContext {
         UnorderedMap<Str, sem::AttrValue> byVarname;
         if (auto default_vars = res.block->attrs.getNamed("var")) {
             for (auto const& var : default_vars->items) {
-                EVAL_TRACE(fmt("Default variable {}", var));
+                EVAL_TRACE(hstd::fmt("Default variable {}", var));
                 byVarname.insert_or_assign(var.varname.value(), var);
             }
         }
 
         if (res.callsiteVars) {
             for (auto const& var : res.callsiteVars->positional.items) {
-                EVAL_TRACE(fmt("Callsite variable {}", var));
+                EVAL_TRACE(hstd::fmt("Callsite variable {}", var));
                 if (var.varname) { byVarname.insert_or_assign(var.varname.value(), var); }
             }
         }
@@ -370,7 +373,7 @@ struct EvalContext {
             } else {
                 value = attr.getString();
             }
-            EVAL_TRACE(fmt("Var '{}' value is '{}'", var.name, value.dump()));
+            EVAL_TRACE(hstd::fmt("Var '{}' value is '{}'", var.name, value.dump()));
             var.value = value;
             input.argList.push_back(var);
         }
@@ -403,7 +406,8 @@ struct EvalContext {
                     return imm::ImmAstReplaceGroup{};
                 } else {
                     EVAL_TRACE(
-                        fmt("Updating AST with new eval result, target "
+                        hstd::fmt(
+                            "Updating AST with new eval result, target "
                             "{}, result handling {} result format {} new "
                             "node {}",
                             target.uniq(),
@@ -480,25 +484,28 @@ struct EvalContext {
             CallParams call = getTargetBlock(adapter);
 
             if (!call.block.isNil()) {
-                EVAL_TRACE(fmt(
-                    "Evaluating language '{}' at {}", call.block->lang, call.block->loc));
+                EVAL_TRACE(
+                    hstd::fmt(
+                        "Evaluating language '{}' at {}",
+                        call.block->lang,
+                        call.block->loc));
                 EVAL_SCOPE();
 
                 auto input  = convertInput(call);
                 auto output = conf.evalBlock(input);
 
                 for (auto const& it : output) {
-                    if (!it.cmd) { EVAL_TRACE(fmt("cmd: {}", it.cmd)); }
-                    if (!it.args.empty()) { EVAL_TRACE(fmt("args: {}", it.args)); }
-                    EVAL_TRACE(fmt("code: {}", it.code));
-                    if (!it.cwd.empty()) { EVAL_TRACE(fmt("cwd: {}", it.cwd)); }
+                    if (!it.cmd) { EVAL_TRACE(hstd::fmt("cmd: {}", it.cmd)); }
+                    if (!it.args.empty()) { EVAL_TRACE(hstd::fmt("args: {}", it.args)); }
+                    EVAL_TRACE(hstd::fmt("code: {}", it.code));
+                    if (!it.cwd.empty()) { EVAL_TRACE(hstd::fmt("cwd: {}", it.cwd)); }
 
                     if (!it.stderrText.empty()) {
-                        EVAL_TRACE(fmt("stderr:\n{}", it.stderrText));
+                        EVAL_TRACE(hstd::fmt("stderr:\n{}", it.stderrText));
                     }
 
                     if (!it.stdoutText.empty()) {
-                        EVAL_TRACE(fmt("stdout:\n{}", it.stdoutText));
+                        EVAL_TRACE(hstd::fmt("stdout:\n{}", it.stdoutText));
                     }
                 }
 
@@ -523,7 +530,8 @@ struct EvalContext {
             "/tmp/codeblock_eval_final.txt",
             version.getRootAdapter().treeRepr(repr_conf).toString(false));
 
-        EVAL_TRACE(fmt("Converting final root result {} back to sem", version.getRoot()));
+        EVAL_TRACE(
+            hstd::fmt("Converting final root result {} back to sem", version.getRoot()));
         return org::imm::sem_from_immer(version.getRoot(), *version.context);
     }
 };

--- a/src/haxorg/base_lexer/base_token.hpp
+++ b/src/haxorg/base_lexer/base_token.hpp
@@ -21,20 +21,20 @@ using OrgTokenId = TokenId<OrgTokenKind, OrgFill>;
 
 
 template <>
-struct fmt::formatter<org::parse::OrgFill> : fmt::formatter<std::string> {
-
+struct fmt::formatter<org::parse::OrgFill> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(org::parse::OrgFill const& p, fmt::format_context& ctx) const {
-        fmt::formatter<std::string>{}.format("<", ctx);
+        ::hstd::fmt_ctx("<", ctx);
         ::hstd::fmt_ctx(escape_for_write(p.text), ctx);
-        fmt::formatter<std::string>{}.format(">", ctx);
+        ::hstd::fmt_ctx(">", ctx);
         if (p.loc.has_value()) {
             ::hstd::fmt_ctx(":", ctx);
             ::hstd::fmt_ctx(p.loc->line, ctx);
-            fmt::formatter<std::string>{}.format(":", ctx);
+            ::hstd::fmt_ctx(":", ctx);
             ::hstd::fmt_ctx(p.loc->column, ctx);
-            fmt::formatter<std::string>{}.format(":", ctx);
+            ::hstd::fmt_ctx(":", ctx);
             ::hstd::fmt_ctx(p.loc->pos, ctx);
-            fmt::formatter<std::string>{}.format("@", ctx);
+            ::hstd::fmt_ctx("@", ctx);
             ::hstd::fmt_ctx(p.loc->file_id.format(), ctx);
         }
         return ctx.out();

--- a/src/haxorg/base_lexer/base_token.hpp
+++ b/src/haxorg/base_lexer/base_token.hpp
@@ -21,21 +21,20 @@ using OrgTokenId = TokenId<OrgTokenKind, OrgFill>;
 
 
 template <>
-struct std::formatter<org::parse::OrgFill> : std::formatter<std::string> {
-    template <typename FormatContext>
-    FormatContext::iterator format(org::parse::OrgFill const& p, FormatContext& ctx)
-        const {
-        std::formatter<std::string>{}.format("<", ctx);
+struct fmt::formatter<org::parse::OrgFill> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(org::parse::OrgFill const& p, fmt::format_context& ctx) const {
+        fmt::formatter<std::string>{}.format("<", ctx);
         ::hstd::fmt_ctx(escape_for_write(p.text), ctx);
-        std::formatter<std::string>{}.format(">", ctx);
+        fmt::formatter<std::string>{}.format(">", ctx);
         if (p.loc.has_value()) {
             ::hstd::fmt_ctx(":", ctx);
             ::hstd::fmt_ctx(p.loc->line, ctx);
-            std::formatter<std::string>{}.format(":", ctx);
+            fmt::formatter<std::string>{}.format(":", ctx);
             ::hstd::fmt_ctx(p.loc->column, ctx);
-            std::formatter<std::string>{}.format(":", ctx);
+            fmt::formatter<std::string>{}.format(":", ctx);
             ::hstd::fmt_ctx(p.loc->pos, ctx);
-            std::formatter<std::string>{}.format("@", ctx);
+            fmt::formatter<std::string>{}.format("@", ctx);
             ::hstd::fmt_ctx(p.loc->file_id.format(), ctx);
         }
         return ctx.out();

--- a/src/haxorg/base_lexer/base_token_tokenize.cpp
+++ b/src/haxorg/base_lexer/base_token_tokenize.cpp
@@ -58,7 +58,7 @@ struct Cursor {
         LOGIC_ASSERTION_CHECK_FMT(get() == c, "{}", c);
         if (p.TraceState) {
             p.message(
-                fmt("skip {} at {}", escape_literal(std::string{c}), format(5)),
+                hstd::fmt("skip {} at {}", escape_literal(std::string{c}), format(5)),
                 function,
                 line);
         }
@@ -193,7 +193,7 @@ struct Cursor {
             return false;
         } else if (get() == '\n') {
             if (p.TraceState) {
-                p.message(fmt("next line over at {}", format(5)), function, line);
+                p.message(hstd::fmt("next line over at {}", format(5)), function, line);
             }
 
             this->line++;
@@ -287,7 +287,8 @@ struct Cursor {
             lexy::trace_to<Rule>(
                 std::back_insert_iterator(str), lexy::zstring_input(input.data()), opts);
             p.message(
-                fmt("lexy view @ {}:{} {}",
+                hstd::fmt(
+                    "lexy view @ {}:{} {}",
                     line,
                     col,
                     escape_literal(view.substr(0, std::min<int>(40, view.size())))),
@@ -356,7 +357,7 @@ struct Cursor {
 
     std::string format(int ahead = 20) const {
         int end = std::min<int>(ahead, text.size() - pos);
-        return std::format(
+        return fmt::format(
             "col:{} line:{} pos:{}/{} text:{}",
             col,
             line,
@@ -392,7 +393,9 @@ struct Cursor {
         OrgToken const& tok,
         int             line     = __builtin_LINE(),
         char const*     function = __builtin_FUNCTION()) {
-        if (p.TraceState) { p.message(fmt("{} {}", tok, format(10)), function, line); }
+        if (p.TraceState) {
+            p.message(hstd::fmt("{} {}", tok, format(10)), function, line);
+        }
         group->add(tok);
     }
 
@@ -469,7 +472,8 @@ struct Cursor {
             if (start_pos == this->pos) {
                 if (p.TraceState) {
                     p.message(
-                        fmt("No movement around pos {}: {}", start_pos, this->format()));
+                        hstd::fmt(
+                            "No movement around pos {}: {}", start_pos, this->format()));
                 }
             }
 
@@ -724,7 +728,7 @@ void switch_command(Cursor& c) {
         if (c.is_at('_', pos)) { ++pos; }
 
         if (c.is_iat(end, pos)) {
-            c.p.message(fmt("end {} {}", pos, c.format()));
+            c.p.message(hstd::fmt("end {} {}", pos, c.format()));
             pos += end.size();
             return pos;
         } else {
@@ -849,7 +853,7 @@ void switch_command(Cursor& c) {
             dsl::whitespace(dsl::ascii::space) + dsl::p<org_ident>>();
         if (span) {
             auto property_kind = normalize(Str{c.lexy_substr(0, *span)});
-            c.p.message(fmt("property kind {}", property_kind));
+            c.p.message(hstd::fmt("property kind {}", property_kind));
             if (property_kind == "description" || property_kind == "created"
                 || property_kind == "hashtag" || property_kind == "hashtagdef") {
                 head.kind = otk::CmdPropertyText;

--- a/src/haxorg/exporters/Exporter.cpp
+++ b/src/haxorg/exporters/Exporter.cpp
@@ -14,7 +14,7 @@ void Exporter<V, R>::visit(
 template <typename V, typename R>
 template <typename T, typename Kind>
 void Exporter<V, R>::visitVariants(R& res, Kind kind, T const& var) {
-    std::string fieldName = std::format("{}", kind);
+    std::string fieldName = fmt::format("{}", kind);
     _this()->visitField(res, "kind", kind);
     std::visit(
         [&, this](auto const& it) { _this()->visitField(res, fieldName.c_str(), it); },

--- a/src/haxorg/exporters/exportersimplesexpr.cpp
+++ b/src/haxorg/exporters/exportersimplesexpr.cpp
@@ -33,7 +33,7 @@ void org::algo::ExporterSimpleSExpr::visit(Res& res, sem::SemId<sem::Org> org) {
                         OrgSemKind::Par,
                     }
                         .contains(org->getKind())) {
-                    res = b.line({string(std::format("{}", org->getKind()))});
+                    res = b.line({string(fmt::format("{}", org->getKind()))});
 
                     for (const auto& it : org->subnodes) {
                         b.add_at(res, string(" "));
@@ -43,7 +43,7 @@ void org::algo::ExporterSimpleSExpr::visit(Res& res, sem::SemId<sem::Org> org) {
                     visitDispatch(inner, org);
                     res = b.line({
                         string(
-                            std::format("{}", org->getKind())
+                            fmt::format("{}", org->getKind())
                             + (b.at(inner).isStack() ? " " : "")),
                         inner,
                     });

--- a/src/haxorg/exporters/exportersimplesexpr.hpp
+++ b/src/haxorg/exporters/exportersimplesexpr.hpp
@@ -33,7 +33,7 @@ struct ExporterSimpleSExpr : public Exporter<ExporterSimpleSExpr, hstd::layout::
 
     template <org::sem::NotOrg T>
     void visit(Res& res, T const& value) {
-        res = b.line({string(hstd::escape_for_write(std::format("{}", value)))});
+        res = b.line({string(hstd::escape_for_write(fmt::format("{}", value)))});
     }
 
     template <typename T>

--- a/src/haxorg/exporters/exportersimplesexpr.hpp
+++ b/src/haxorg/exporters/exportersimplesexpr.hpp
@@ -4,6 +4,7 @@
 #include <hstd/ext/textlayouter.hpp>
 #include <hstd/stdlib/Formatter.hpp>
 #include <hstd/stdlib/strutils.hpp>
+#include <hstd/stdlib/MapFormatter.hpp>
 
 namespace org::algo {
 

--- a/src/haxorg/exporters/exportertree.cpp
+++ b/src/haxorg/exporters/exportertree.cpp
@@ -22,7 +22,8 @@ void ExporterTree::visitField(int& i, char const* name, CVec<sem::SemId<sem::Org
         return;
     }
     if (skipAsTooNested()) {
-        writeSkip(fmt("too nested stack:{} max:{}", stack.size(), conf.maxTreeDepth));
+        writeSkip(
+            hstd::fmt("too nested stack:{} max:{}", stack.size(), conf.maxTreeDepth));
         return;
     }
 
@@ -52,7 +53,7 @@ void ExporterTree::treeRepr(sem::SemId<sem::Org> org, std::filesystem::path cons
         ExporterTree(os).evalTop(org);
     } else {
         throw FilesystemError::init(
-            std::format("Could not open file {} for writing tree repr", path));
+            fmt::format("Could not open file {} for writing tree repr", path));
     }
 }
 
@@ -67,7 +68,7 @@ ColText ExporterTree::treeRepr(sem::SemId<sem::Org> org, TreeReprConf const& con
 void ExporterTree::init(sem::SemId<sem::Org> org) {
     auto ctx = stack.back();
     indent();
-    os << os.green() << std::format("{}", org->getKind()) << os.end();
+    os << os.green() << fmt::format("{}", org->getKind()) << os.end();
 
     if (conf.withSubnodeIdx && ctx.subnodeIdx != -1) {
         os << " [" << ctx.subnodeIdx << "]";
@@ -100,7 +101,7 @@ void ExporterTree::writeSkip(
 template <typename T>
 void ExporterTree::visitField(int& arg, char const* name, T const& value) {
     if (skipAsEmpty(value)) {
-        writeSkip(fmt("  empty field {}", name), "\n");
+        writeSkip(hstd::fmt("  empty field {}", name), "\n");
         return;
     }
     // Location is printed as a part of 'init'
@@ -121,7 +122,7 @@ void ExporterTree::visitField(int& arg, char const* name, T const& value) {
     } else if constexpr (std::is_same_v<T, Str>) {
         os << " = " << os.yellow() << escape_literal(value) << os.end() << "\n";
     } else if constexpr (std::is_same_v<T, UserTime>) {
-        os << " = " << fmt("align:{} time:{}", value.align, value.format()) << "\n";
+        os << " = " << hstd::fmt("align:{} time:{}", value.align, value.format()) << "\n";
     } else {
         os << "\n";
         visit(arg, value);
@@ -151,7 +152,7 @@ void ExporterTree::visit(int& arg, T const& opt) {
     __scope();
     indent();
     if constexpr (std::is_enum<T>::value) {
-        os << os.red() << std::format("{}", opt) << os.end() << "\n";
+        os << os.red() << fmt::format("{}", opt) << os.end() << "\n";
     } else if constexpr (std::is_same_v<T, Str>) {
         if (conf.withTypeAnnotations) { os << value_metadata<T>::typeName(); }
 

--- a/src/haxorg/exporters/exporteryaml.cpp
+++ b/src/haxorg/exporters/exporteryaml.cpp
@@ -11,7 +11,7 @@ using osm = OrgSemKind;
 
 yaml ExporterYaml::newRes(sem::SemId<sem::Org> org) {
     yaml res;
-    res["kind"] = std::format("{}", org->getKind());
+    res["kind"] = fmt::format("{}", org->getKind());
 
     if (IntSet<osm>{
             osm::Word,

--- a/src/haxorg/exporters/exporteryaml.hpp
+++ b/src/haxorg/exporters/exporteryaml.hpp
@@ -39,7 +39,7 @@ struct ExporterYaml : public Exporter<ExporterYaml, yaml> {
     yaml eval(E value)
         requires(std::is_enum<E>::value)
     {
-        return yaml(std::format("{}", value));
+        return yaml(fmt::format("{}", value));
     }
 
     template <typename T>

--- a/src/haxorg/imm/ImmOrg.cpp
+++ b/src/haxorg/imm/ImmOrg.cpp
@@ -82,9 +82,9 @@ std::string ImmId::getReadableId() const {
         return "nil";
     } else {
         try {
-            return std::format("{}_{}", getKind(), getNodeIndex());
+            return fmt::format("{}_{}", getKind(), getNodeIndex());
         } catch (std::domain_error const& err) {
-            return std::format(
+            return fmt::format(
                 "ERR {} MASK:{:016b} IDX:{:032b}",
                 err.what(),
                 static_cast<u64>(getKind()),
@@ -279,8 +279,8 @@ void treeReprRec(ImmAdapter id, ColStream& os, ImmTreeReprContext const& ctx) {
     os.indent(ctx.level * 2);
     // TODO: Align the subtree kind and readable ID using fixed width
     // padding on the subtree.
-    os << fmt("{} {}", id->getKind(), id.id.getReadableId());
-    if (!ctx.path.empty()) { os << fmt(" PATH:{}", ctx.path); }
+    os << hstd::fmt("{} {}", id->getKind(), id.id.getReadableId());
+    if (!ctx.path.empty()) { os << hstd::fmt(" PATH:{}", ctx.path); }
     bool printed_field_repr    = false;
     auto print_detailed_fields = [&]() {
         switch_node_value(id.id, id.ctx.lock(), [&]<typename N>(N const& value) {
@@ -320,7 +320,7 @@ void treeReprRec(ImmAdapter id, ColStream& os, ImmTreeReprContext const& ctx) {
 
         for (auto const& sub : id.getAllSubnodes(std::nullopt)) {
             os.indent((ctx.level + 1) * 2);
-            os << fmt("{}", sub.path);
+            os << hstd::fmt("{}", sub.path);
             os << "\n";
             treeReprRec(sub, os, ctx.addLevel(printed_field_repr ? 3 : 2));
         }
@@ -354,16 +354,16 @@ Str ImmAdapter::selfSelect() const {
         auto const& i = step.path.path;
         if (i.size() == 2 && i.at(0).isFieldName() && i.at(1).isIndex()
             && i.at(0).getFieldName().name.getName() == "subnodes") {
-            result += fmt(".at({})", i.at(1).getIndex().index);
+            result += hstd::fmt(".at({})", i.at(1).getIndex().index);
         } else if (i.size() == 2 && i.at(0).isFieldName() && i.at(1).isAnyKey()) {
-            result += fmt(
+            result += hstd::fmt(
                 R"(.{}.at("{}"))",
                 i.at(0).getFieldName().name.getName(),
                 i.at(1).getAnyKey().get<Str>());
         } else if (i.size() == 1 && i.at(0).isFieldName()) {
-            return fmt(".{}", i.at(0).getFieldName().name.getName());
+            return hstd::fmt(".{}", i.at(0).getFieldName().name.getName());
         } else if (i.size() == 2 && i.at(0).isFieldName() && i.at(1).isIndex()) {
-            result += fmt(
+            result += hstd::fmt(
                 ".{}.at({})",
                 i.at(0).getFieldName().name.getName(),
                 i.at(1).getIndex().index);
@@ -642,7 +642,7 @@ void ImmAstEditContext::updateTracking(ImmId const& node, bool add) {
     auto search_radio_targets = [&](ImmAdapter const& id) {
         __perf_trace("imm", "search radio targets");
         for (auto const& target : id.subAs<org::imm::ImmRadioTarget>(false)) {
-            message(fmt("Node {} contains radio target {}", node, target));
+            message(hstd::fmt("Node {} contains radio target {}", node, target));
             edit_radio_targets(target->words, target.id);
         }
     };
@@ -658,8 +658,11 @@ void ImmAstEditContext::updateTracking(ImmId const& node, bool add) {
                             __perf_trace("imm", "track names");
                             for (auto const& name : adapter.getName()) {
                                 if (ctx.lock()->debug->TraceState) {
-                                    message(fmt(
-                                        "Tracking name '{}' for node {}", name, node));
+                                    message(
+                                        hstd::fmt(
+                                            "Tracking name '{}' for node {}",
+                                            name,
+                                            node));
                                 }
                                 if (add) {
                                     transientTrack.names.set(name, node);
@@ -685,7 +688,7 @@ void ImmAstEditContext::updateTracking(ImmId const& node, bool add) {
                 __perf_trace("imm", "track subtree");
                 if (auto id = subtree.treeId.get(); id) {
                     if (ctx.lock()->debug->TraceState) {
-                        message(fmt("Subtree ID {}", id.value()));
+                        message(hstd::fmt("Subtree ID {}", id.value()));
                     }
                     if (add) {
                         transientTrack.subtrees.set(*id, node);
@@ -697,7 +700,7 @@ void ImmAstEditContext::updateTracking(ImmId const& node, bool add) {
                 for (auto const& id :
                      org::getSubtreeProperties<sem::NamedProperty::CustomId>(subtree)) {
                     if (ctx.lock()->debug->TraceState) {
-                        message(fmt("Subtree custom ID {}", id.value));
+                        message(hstd::fmt("Subtree custom ID {}", id.value));
                     }
                     if (add) {
                         transientTrack.customIds.set(id.value, node);
@@ -726,7 +729,7 @@ void ImmAstEditContext::updateTracking(ImmId const& node, bool add) {
                 if (par.isFootnoteDefinition()) {
                     auto id = par.getFootnoteName().value();
                     if (ctx.lock()->debug->TraceState) {
-                        message(fmt("Footnote ID {}", id));
+                        message(hstd::fmt("Footnote ID {}", id));
                     }
                     if (add) {
                         transientTrack.footnotes.set(id, node);
@@ -795,8 +798,8 @@ hstd::SPtr<graph::gv::GraphGroup> org::imm::toGraphviz(
     auto get_graph = [&](int epoch) -> hstd::SPtr<gv::GraphGroup> {
         if (conf.withEpochClusters && epoch < history.size()) {
             if (!gvClusters.has(epoch)) {
-                auto sub = g->newSubgraph(fmt("epoch_{}", epoch));
-                sub->setLabel(fmt("Epoch {}", epoch));
+                auto sub = g->newSubgraph(hstd::fmt("epoch_{}", epoch));
+                sub->setLabel(hstd::fmt("Epoch {}", epoch));
                 gvClusters.resize_at(epoch, sub);
             }
 
@@ -825,13 +828,13 @@ hstd::SPtr<graph::gv::GraphGroup> org::imm::toGraphviz(
                     auto prefix    = left_aligned(name, maxFieldWidth);
                     if (value_fmt.contains('\n')) {
                         auto split = hstd::split(value_fmt, '\n');
-                        label.push_back(fmt("{}: {}", prefix, split.at(0)));
+                        label.push_back(hstd::fmt("{}: {}", prefix, split.at(0)));
                         for (int i = 1; i < split.size(); ++i) {
                             label.push_back(
                                 Str{" "}.repeated(prefix.size() + 2) + split.at(i));
                         }
                     } else {
-                        label.push_back(fmt("{}: {}", prefix, value_fmt));
+                        label.push_back(hstd::fmt("{}: {}", prefix, value_fmt));
                     }
                 };
 
@@ -855,13 +858,15 @@ hstd::SPtr<graph::gv::GraphGroup> org::imm::toGraphviz(
                                     for (auto const& it :
                                          hstd::enumerator(group.positional.items)) {
                                         attrs.push_back(
-                                            fmt("[{}] = {}", it.index(), it.value()));
+                                            hstd::fmt(
+                                                "[{}] = {}", it.index(), it.value()));
                                     }
 
                                     for (auto const& key : sorted(group.named.keys())) {
                                         for (auto const& it : group.named.at(key).items) {
                                             attrs.push_back(
-                                                fmt("{} = {}", escape_literal(key), it));
+                                                hstd::fmt(
+                                                    "{} = {}", escape_literal(key), it));
                                         }
                                     }
 
@@ -1259,7 +1264,8 @@ RadioTargetSearchResult tryRadioTargetSearch(
         auto sourceWord = atSource->dyn_cast<org::imm::ImmLeaf>();
         if (sourceWord == nullptr) {
             ctx->debug->message(
-                fmt("Source word at offset {} is not "
+                hstd::fmt(
+                    "Source word at offset {} is not "
                     "a leaf",
                     sourceOffset));
             // Source word at position is not a final
@@ -1272,14 +1278,15 @@ RadioTargetSearchResult tryRadioTargetSearch(
                 result.target = ImmSubnodeGroup::RadioTarget{
                     .target = targetId, .nodes = Vec<ImmAdapter>{sub.at(range)}};
                 ctx->debug->message(
-                    fmt("Fully matched radio target "
+                    hstd::fmt(
+                        "Fully matched radio target "
                         "offset, subnode range {} is a "
                         "radio target linked with {}",
                         range,
                         targetId));
                 auto __scope = ctx->debug->begin_scope();
                 for (auto const& it : result.target->nodes) {
-                    ctx->debug->message(fmt("- target {}", it));
+                    ctx->debug->message(hstd::fmt("- target {}", it));
                 }
                 result.nextGroupIdx = groupingIdx + sourceOffset;
                 // Successfully found radio target,
@@ -1319,7 +1326,8 @@ Vec<ImmSubnodeGroup> imm::getSubnodeGroups(
 
     if (ctx->debug->TraceState) {
         ctx->debug->message(
-            fmt("Radio targets count {} using context {:#010x}",
+            hstd::fmt(
+                "Radio targets count {} using context {:#010x}",
                 track.radioTargets.size(),
                 reinterpret_cast<intptr_t>(ctx.get())));
 
@@ -1327,7 +1335,7 @@ Vec<ImmSubnodeGroup> imm::getSubnodeGroups(
             ctx->debug->message(_dfmt_expr(key, value));
         }
 
-        ctx->debug->message(fmt("Get subnode groups for {}", node.uniq()));
+        ctx->debug->message(hstd::fmt("Get subnode groups for {}", node.uniq()));
     }
     auto __scope = ctx->debug->begin_scope();
 
@@ -1335,17 +1343,17 @@ Vec<ImmSubnodeGroup> imm::getSubnodeGroups(
         ImmAdapter const& it = sub.at(groupingIdx);
         if (auto leaf = it->dyn_cast<ImmLeaf>();
             leaf != nullptr && !leaf->is(OrgSemKind::Space)) {
-            ctx->debug->message(fmt("Subnode {} is leaf", groupingIdx));
+            ctx->debug->message(hstd::fmt("Subnode {} is leaf", groupingIdx));
             Vec<ImmId> const* radioTargets = track.radioTargets.find(leaf->text.get());
             if (radioTargets == nullptr) {
                 ctx->debug->message(
-                    fmt("No radio target starting with word '{}'", leaf->text));
+                    hstd::fmt("No radio target starting with word '{}'", leaf->text));
                 result.push_back(ImmSubnodeGroup{ImmSubnodeGroup::Single{.node = it}});
             } else {
-                ctx->debug->message(fmt("Found potential radio targets"));
+                ctx->debug->message(hstd::fmt("Found potential radio targets"));
                 RadioTargetSearchResult searchResult;
                 for (ImmId const& radioId : *radioTargets) {
-                    ctx->debug->message(fmt("Trying radio ID {}", radioId));
+                    ctx->debug->message(hstd::fmt("Trying radio ID {}", radioId));
                     auto __scope      = ctx->debug->begin_scope();
                     auto radioAdapter = it.ctx.lock()->adaptUnrooted(radioId);
 
@@ -1361,7 +1369,8 @@ Vec<ImmSubnodeGroup> imm::getSubnodeGroups(
                              org::getSubtreeProperties<sem::NamedProperty::RadioId>(
                                  subtree.value())) {
                             ctx->debug->message(
-                                fmt("Searcing for radio target with words {}", id.words));
+                                hstd::fmt(
+                                    "Searcing for radio target with words {}", id.words));
                             searchResult = tryRadioTargetSearch(
                                 id.words, sub, groupingIdx, subtree.id, ctx);
                             if (searchResult.target) { goto radio_search_exit; }
@@ -1417,7 +1426,7 @@ Vec<ImmSubnodeGroup> imm::getSubnodeGroups(
 
     {
         auto _s = ctx->debug->begin_scope("Final result grouping");
-        for (auto const& it : result) { ctx->debug->message(fmt("Final {}", it)); }
+        for (auto const& it : result) { ctx->debug->message(hstd::fmt("Final {}", it)); }
     }
 
     int totalNodes = 0;

--- a/src/haxorg/imm/ImmOrg.hpp
+++ b/src/haxorg/imm/ImmOrg.hpp
@@ -126,9 +126,10 @@ struct [[refl]] ImmPathStep {
 } // namespace org::imm
 
 template <>
-struct std::formatter<org::imm::ImmPathStep> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(org::imm::ImmPathStep const& p, FormatContext& ctx) const {
+struct fmt::formatter<org::imm::ImmPathStep> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(org::imm::ImmPathStep const& p, fmt::format_context& ctx)
+        const {
         return hstd::ReflPathFormatter<org::imm::ImmReflPathTag>{}.format(p.path, ctx);
     }
 };
@@ -1539,56 +1540,57 @@ struct std::hash<org::imm::ImmPath> {
 
 
 template <>
-struct std::formatter<org::imm::ImmAstStore*>
+struct fmt::formatter<org::imm::ImmAstStore*>
     : hstd::std_format_ptr_as_hex<org::imm::ImmAstStore> {};
 
 template <>
-struct std::formatter<org::imm::ImmAstReplaceEpoch*>
+struct fmt::formatter<org::imm::ImmAstReplaceEpoch*>
     : hstd::std_format_ptr_as_hex<org::imm::ImmAstReplaceEpoch> {};
 
 template <>
-struct std::formatter<org::imm::ImmAstContext*>
+struct fmt::formatter<org::imm::ImmAstContext*>
     : hstd::std_format_ptr_as_hex<org::imm::ImmAstContext> {};
 
 template <>
-struct std::formatter<org::imm::ParentPathMap*>
+struct fmt::formatter<org::imm::ParentPathMap*>
     : hstd::std_format_ptr_as_hex_and_value<org::imm::ParentPathMap> {};
 
 template <>
-struct std::formatter<org::imm::ImmAstTrackingMap*>
+struct fmt::formatter<org::imm::ImmAstTrackingMap*>
     : hstd::std_format_ptr_as_value<org::imm::ImmAstTrackingMap> {};
 
 
 template <>
-struct std::formatter<org::imm::ImmPath> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(org::imm::ImmPath const& p, FormatContext& ctx) const {
+struct fmt::formatter<org::imm::ImmPath> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(org::imm::ImmPath const& p, fmt::format_context& ctx) const {
         return hstd::fmt_ctx(hstd::fmt("{}//{}", p.root, p.path), ctx);
     }
 };
 
 template <>
-struct std::formatter<org::imm::ImmUniqId> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(org::imm::ImmUniqId const& p, FormatContext& ctx) const {
+struct fmt::formatter<org::imm::ImmUniqId> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(org::imm::ImmUniqId const& p, fmt::format_context& ctx) const {
         return hstd::fmt_ctx(hstd::fmt("{}->{}", p.path, p.id), ctx);
     }
 };
 
 
 template <>
-struct std::formatter<org::imm::ImmAstStore> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(org::imm::ImmAstStore const& p, FormatContext& ctx) const {
+struct fmt::formatter<org::imm::ImmAstStore> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(org::imm::ImmAstStore const& p, fmt::format_context& ctx)
+        const {
         return hstd::fmt_ctx("ImmAstStore{}", ctx);
     }
 };
 
 
 template <>
-struct std::formatter<org::imm::ImmAdapter> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(org::imm::ImmAdapter const& p, FormatContext& ctx) const {
+struct fmt::formatter<org::imm::ImmAdapter> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(org::imm::ImmAdapter const& p, fmt::format_context& ctx) const {
         return hstd::fmt_ctx(hstd::fmt("{}->{}", p.path, p.id), ctx);
     }
 };

--- a/src/haxorg/imm/ImmOrg.hpp
+++ b/src/haxorg/imm/ImmOrg.hpp
@@ -126,8 +126,8 @@ struct [[refl]] ImmPathStep {
 } // namespace org::imm
 
 template <>
-struct fmt::formatter<org::imm::ImmPathStep> : fmt::formatter<std::string> {
-
+struct fmt::formatter<org::imm::ImmPathStep> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(org::imm::ImmPathStep const& p, fmt::format_context& ctx)
         const {
         return hstd::ReflPathFormatter<org::imm::ImmReflPathTag>{}.format(p.path, ctx);
@@ -1561,16 +1561,16 @@ struct fmt::formatter<org::imm::ImmAstTrackingMap*>
 
 
 template <>
-struct fmt::formatter<org::imm::ImmPath> : fmt::formatter<std::string> {
-
+struct fmt::formatter<org::imm::ImmPath> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(org::imm::ImmPath const& p, fmt::format_context& ctx) const {
         return hstd::fmt_ctx(hstd::fmt("{}//{}", p.root, p.path), ctx);
     }
 };
 
 template <>
-struct fmt::formatter<org::imm::ImmUniqId> : fmt::formatter<std::string> {
-
+struct fmt::formatter<org::imm::ImmUniqId> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(org::imm::ImmUniqId const& p, fmt::format_context& ctx) const {
         return hstd::fmt_ctx(hstd::fmt("{}->{}", p.path, p.id), ctx);
     }
@@ -1578,8 +1578,8 @@ struct fmt::formatter<org::imm::ImmUniqId> : fmt::formatter<std::string> {
 
 
 template <>
-struct fmt::formatter<org::imm::ImmAstStore> : fmt::formatter<std::string> {
-
+struct fmt::formatter<org::imm::ImmAstStore> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(org::imm::ImmAstStore const& p, fmt::format_context& ctx)
         const {
         return hstd::fmt_ctx("ImmAstStore{}", ctx);
@@ -1588,8 +1588,8 @@ struct fmt::formatter<org::imm::ImmAstStore> : fmt::formatter<std::string> {
 
 
 template <>
-struct fmt::formatter<org::imm::ImmAdapter> : fmt::formatter<std::string> {
-
+struct fmt::formatter<org::imm::ImmAdapter> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(org::imm::ImmAdapter const& p, fmt::format_context& ctx) const {
         return hstd::fmt_ctx(hstd::fmt("{}->{}", p.path, p.id), ctx);
     }

--- a/src/haxorg/imm/ImmOrgAdapter.hpp
+++ b/src/haxorg/imm/ImmOrgAdapter.hpp
@@ -90,8 +90,8 @@ org::imm::ImmId immer_from_sem(
 
 
 template <typename T>
-struct fmt::formatter<org::imm::ImmAdapterT<T>> : fmt::formatter<std::string> {
-
+struct fmt::formatter<org::imm::ImmAdapterT<T>> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(org::imm::ImmAdapterT<T> const& p, fmt::format_context& ctx)
         const {
         return hstd::fmt_ctx(p.id, ctx);

--- a/src/haxorg/imm/ImmOrgAdapter.hpp
+++ b/src/haxorg/imm/ImmOrgAdapter.hpp
@@ -90,9 +90,10 @@ org::imm::ImmId immer_from_sem(
 
 
 template <typename T>
-struct std::formatter<org::imm::ImmAdapterT<T>> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(org::imm::ImmAdapterT<T> const& p, FormatContext& ctx) const {
+struct fmt::formatter<org::imm::ImmAdapterT<T>> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(org::imm::ImmAdapterT<T> const& p, fmt::format_context& ctx)
+        const {
         return hstd::fmt_ctx(p.id, ctx);
     }
 };

--- a/src/haxorg/imm/ImmOrgBase.hpp
+++ b/src/haxorg/imm/ImmOrgBase.hpp
@@ -189,10 +189,9 @@ template <typename T>
 struct fmt::formatter<hstd::ext::ImmSet<T>> {
     constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(hstd::ext::ImmSet<T> const& p, fmt::format_context& ctx) const {
-        fmt::formatter<std::string> fmt;
-        fmt.format("{", ctx);
-        fmt.format(join(", ", p), ctx);
-        return fmt.format("}", ctx);
+        hstd::fmt_ctx("{", ctx);
+        hstd::fmt_ctx(join(", ", p), ctx);
+        return hstd::fmt_ctx("}", ctx);
     }
 };
 

--- a/src/haxorg/imm/ImmOrgBase.hpp
+++ b/src/haxorg/imm/ImmOrgBase.hpp
@@ -80,9 +80,10 @@ struct [[refl]] ImmReflFieldId {
 } // namespace org::imm
 
 template <>
-struct std::formatter<org::imm::ImmReflFieldId> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(org::imm::ImmReflFieldId const& p, FormatContext& ctx) const {
+struct fmt::formatter<org::imm::ImmReflFieldId> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(org::imm::ImmReflFieldId const& p, fmt::format_context& ctx)
+        const {
         return fmt_ctx(p.getName(), ctx);
     }
 };
@@ -151,9 +152,9 @@ struct hstd::ReflVisitor<hstd::ext::ImmBox<T>, Tag> {
 };
 
 template <typename T>
-struct std::formatter<hstd::ext::ImmBox<T>> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(hstd::ext::ImmBox<T> const& p, FormatContext& ctx) const {
+struct fmt::formatter<hstd::ext::ImmBox<T>> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(hstd::ext::ImmBox<T> const& p, fmt::format_context& ctx) const {
         hstd::fmt_ctx("Box{", ctx);
         hstd::fmt_ctx(p.get(), ctx);
         return hstd::fmt_ctx("}", ctx);
@@ -161,9 +162,11 @@ struct std::formatter<hstd::ext::ImmBox<T>> : std::formatter<std::string> {
 };
 
 template <>
-struct std::formatter<hstd::ext::ImmBox<std::string>> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(hstd::ext::ImmBox<std::string> const& p, FormatContext& ctx) const {
+struct fmt::formatter<hstd::ext::ImmBox<std::string>> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(
+        hstd::ext::ImmBox<std::string> const& p,
+        fmt::format_context&                  ctx) const {
         hstd::fmt_ctx("Box{", ctx);
         hstd::fmt_ctx(hstd::escape_literal(p.get()), ctx);
         return hstd::fmt_ctx("}", ctx);
@@ -171,9 +174,10 @@ struct std::formatter<hstd::ext::ImmBox<std::string>> : std::formatter<std::stri
 };
 
 template <>
-struct std::formatter<hstd::ext::ImmBox<hstd::Str>> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(hstd::ext::ImmBox<hstd::Str> const& p, FormatContext& ctx) const {
+struct fmt::formatter<hstd::ext::ImmBox<hstd::Str>> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(hstd::ext::ImmBox<hstd::Str> const& p, fmt::format_context& ctx)
+        const {
         hstd::fmt_ctx("Box{", ctx);
         hstd::fmt_ctx(hstd::escape_literal(p.get()), ctx);
         return hstd::fmt_ctx("}", ctx);
@@ -182,11 +186,10 @@ struct std::formatter<hstd::ext::ImmBox<hstd::Str>> : std::formatter<std::string
 
 
 template <typename T>
-struct std::formatter<hstd::ext::ImmSet<T>> : std::formatter<std::string> {
-    template <typename FormatContext>
-    FormatContext::iterator format(hstd::ext::ImmSet<T> const& p, FormatContext& ctx)
-        const {
-        std::formatter<std::string> fmt;
+struct fmt::formatter<hstd::ext::ImmSet<T>> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(hstd::ext::ImmSet<T> const& p, fmt::format_context& ctx) const {
+        fmt::formatter<std::string> fmt;
         fmt.format("{", ctx);
         fmt.format(join(", ", p), ctx);
         return fmt.format("}", ctx);
@@ -204,15 +207,15 @@ using ImmMapTransientDefault = immer::map_transient<
 
 
 template <typename K, typename V>
-struct std::formatter<ImmMapTransientDefault<K, V>>
+struct fmt::formatter<ImmMapTransientDefault<K, V>>
     : hstd::std_kv_tuple_iterator_formatter<K, V, ImmMapTransientDefault<K, V>> {};
 
 template <typename K, typename V>
-struct std::formatter<hstd::ext::ImmMap<K, V>>
+struct fmt::formatter<hstd::ext::ImmMap<K, V>>
     : hstd::std_kv_tuple_iterator_formatter<K, V, hstd::ext::ImmMap<K, V>> {};
 
 template <typename K, typename V>
-struct std::formatter<immer::map<K, V>>
+struct fmt::formatter<immer::map<K, V>>
     : hstd::std_kv_tuple_iterator_formatter<K, V, immer::map<K, V>> {};
 
 
@@ -362,9 +365,9 @@ struct [[refl]] ImmOrg {
 } // namespace org::imm
 
 template <>
-struct std::formatter<org::imm::ImmId> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(org::imm::ImmId const& p, FormatContext& ctx) const {
+struct fmt::formatter<org::imm::ImmId> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(org::imm::ImmId const& p, fmt::format_context& ctx) const {
         return hstd::fmt_ctx(p.getReadableId(), ctx);
     }
 };

--- a/src/haxorg/imm/ImmOrgBase.hpp
+++ b/src/haxorg/imm/ImmOrgBase.hpp
@@ -80,8 +80,8 @@ struct [[refl]] ImmReflFieldId {
 } // namespace org::imm
 
 template <>
-struct fmt::formatter<org::imm::ImmReflFieldId> : fmt::formatter<std::string> {
-
+struct fmt::formatter<org::imm::ImmReflFieldId> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(org::imm::ImmReflFieldId const& p, fmt::format_context& ctx)
         const {
         return fmt_ctx(p.getName(), ctx);
@@ -152,8 +152,8 @@ struct hstd::ReflVisitor<hstd::ext::ImmBox<T>, Tag> {
 };
 
 template <typename T>
-struct fmt::formatter<hstd::ext::ImmBox<T>> : fmt::formatter<std::string> {
-
+struct fmt::formatter<hstd::ext::ImmBox<T>> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(hstd::ext::ImmBox<T> const& p, fmt::format_context& ctx) const {
         hstd::fmt_ctx("Box{", ctx);
         hstd::fmt_ctx(p.get(), ctx);
@@ -162,8 +162,8 @@ struct fmt::formatter<hstd::ext::ImmBox<T>> : fmt::formatter<std::string> {
 };
 
 template <>
-struct fmt::formatter<hstd::ext::ImmBox<std::string>> : fmt::formatter<std::string> {
-
+struct fmt::formatter<hstd::ext::ImmBox<std::string>> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(
         hstd::ext::ImmBox<std::string> const& p,
         fmt::format_context&                  ctx) const {
@@ -174,8 +174,8 @@ struct fmt::formatter<hstd::ext::ImmBox<std::string>> : fmt::formatter<std::stri
 };
 
 template <>
-struct fmt::formatter<hstd::ext::ImmBox<hstd::Str>> : fmt::formatter<std::string> {
-
+struct fmt::formatter<hstd::ext::ImmBox<hstd::Str>> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(hstd::ext::ImmBox<hstd::Str> const& p, fmt::format_context& ctx)
         const {
         hstd::fmt_ctx("Box{", ctx);
@@ -186,8 +186,8 @@ struct fmt::formatter<hstd::ext::ImmBox<hstd::Str>> : fmt::formatter<std::string
 
 
 template <typename T>
-struct fmt::formatter<hstd::ext::ImmSet<T>> : fmt::formatter<std::string> {
-
+struct fmt::formatter<hstd::ext::ImmSet<T>> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(hstd::ext::ImmSet<T> const& p, fmt::format_context& ctx) const {
         fmt::formatter<std::string> fmt;
         fmt.format("{", ctx);
@@ -365,8 +365,8 @@ struct [[refl]] ImmOrg {
 } // namespace org::imm
 
 template <>
-struct fmt::formatter<org::imm::ImmId> : fmt::formatter<std::string> {
-
+struct fmt::formatter<org::imm::ImmId> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(org::imm::ImmId const& p, fmt::format_context& ctx) const {
         return hstd::fmt_ctx(p.getReadableId(), ctx);
     }

--- a/src/haxorg/imm/ImmOrgEdit.cpp
+++ b/src/haxorg/imm/ImmOrgEdit.cpp
@@ -2,6 +2,7 @@
 #include <immer/flex_vector_transient.hpp>
 #include <hstd/stdlib/OptFormatter.hpp>
 #include <haxorg/imm/ImmOrgAdapter.hpp>
+#include <hstd/stdlib/VecFormatter.hpp>
 
 using namespace org;
 using namespace org::imm;
@@ -12,7 +13,7 @@ ImmAstReplace org::imm::setSubnode(
     ImmId              newSubnode,
     int                position,
     ImmAstEditContext& ctx) {
-    AST_EDIT_MSG(fmt("Set {}[{}] = {}", node, position, newSubnode));
+    AST_EDIT_MSG(hstd::fmt("Set {}[{}] = {}", node, position, newSubnode));
     auto res = setSubnodes(node, node->subnodes.set(position, newSubnode), ctx);
     return res;
 }
@@ -22,7 +23,7 @@ ImmAstReplace org::imm::insertSubnode(
     ImmId              add,
     int                position,
     ImmAstEditContext& ctx) {
-    AST_EDIT_MSG(fmt("Insert {}[{}] = {}", node, position, add));
+    AST_EDIT_MSG(hstd::fmt("Insert {}[{}] = {}", node, position, add));
     return setSubnodes(node, node->subnodes.insert(position, add), ctx);
 }
 
@@ -31,7 +32,7 @@ ImmAstReplace org::imm::insertSubnodes(
     Vec<ImmId>         add,
     int                position,
     ImmAstEditContext& ctx) {
-    AST_EDIT_MSG(fmt("Insert {} at {} in {}b", add, position, node));
+    AST_EDIT_MSG(hstd::fmt("Insert {} at {} in {}b", add, position, node));
     Vec<ImmId> u;
     LOGIC_ASSERTION_CHECK_FMT(0 <= position, "{}", position);
 
@@ -54,7 +55,7 @@ ImmAstReplace org::imm::dropSubnode(
     ImmAdapter const&  node,
     int                position,
     ImmAstEditContext& ctx) {
-    AST_EDIT_MSG(fmt("Drop subnode {}[{}]", node, position));
+    AST_EDIT_MSG(hstd::fmt("Drop subnode {}[{}]", node, position));
     return setSubnodes(node, node->subnodes.erase(position), ctx);
 }
 
@@ -87,7 +88,7 @@ ImmAstReplaceGroup org::imm::demoteSubtree(
 
     if (move == SubtreeMove::EnsureLevels || move == SubtreeMove::ForceLevels) {
 
-        AST_EDIT_MSG(fmt("Demote subtree {}", node));
+        AST_EDIT_MSG(hstd::fmt("Demote subtree {}", node));
         Func<Opt<ImmAstReplace>(ImmAdapter const&)> aux;
         aux = [&](ImmAdapter const& target) -> Opt<ImmAstReplace> {
             for (auto const& sub : target.sub()) {
@@ -117,7 +118,8 @@ ImmAstReplaceGroup org::imm::demoteSubtree(
                 // Demoting subtree caused reparenting, removing the
                 // node from the old subtree.
                 AST_EDIT_MSG(
-                    fmt("Subtree demote reparenting. Adjacent:{}, "
+                    hstd::fmt(
+                        "Subtree demote reparenting. Adjacent:{}, "
                         "replaced:{}, "
                         "target drop:{}",
                         adjacent->id,
@@ -129,7 +131,8 @@ ImmAstReplaceGroup org::imm::demoteSubtree(
                 edits.incl(appendSubnode(*adjacent, update.replaced.id, ctx));
             } else {
                 AST_EDIT_MSG(
-                    fmt("Subtree demote, no reparenting, levels are "
+                    hstd::fmt(
+                        "Subtree demote, no reparenting, levels are "
                         "ok. "
                         "Adjacent:{}, replaced:{}",
                         adjacentTree->level,
@@ -137,13 +140,14 @@ ImmAstReplaceGroup org::imm::demoteSubtree(
             }
         } else {
             AST_EDIT_MSG(
-                fmt("Subtree demote, no reparenting parent:{} "
+                hstd::fmt(
+                    "Subtree demote, no reparenting parent:{} "
                     "adjacent:{}",
                     parent,
                     adjacent));
         }
     } else {
-        AST_EDIT_MSG(fmt("Physical demote subtree {}", node));
+        AST_EDIT_MSG(hstd::fmt("Physical demote subtree {}", node));
         Vec<ImmId> demotedSubnodes;
         Vec<ImmId> reparentedSubnodes;
         auto       tree  = node.as<org::imm::ImmSubtree>();
@@ -160,8 +164,8 @@ ImmAstReplaceGroup org::imm::demoteSubtree(
             }
         }
 
-        AST_EDIT_MSG(fmt("New subnode list {}", demotedSubnodes));
-        AST_EDIT_MSG(fmt("Move subnode list {}", reparentedSubnodes));
+        AST_EDIT_MSG(hstd::fmt("New subnode list {}", demotedSubnodes));
+        AST_EDIT_MSG(hstd::fmt("Move subnode list {}", reparentedSubnodes));
 
 
         {
@@ -175,7 +179,7 @@ ImmAstReplaceGroup org::imm::demoteSubtree(
                     return value;
                 });
 
-            AST_EDIT_MSG(fmt("Update subtree {}", update));
+            AST_EDIT_MSG(hstd::fmt("Update subtree {}", update));
             edits.incl(update);
 
             if (!reparentedSubnodes.empty()) {
@@ -183,7 +187,7 @@ ImmAstReplaceGroup org::imm::demoteSubtree(
                 auto parent            = tree.getParent().value();
                 auto newParentSubnodes = edits.newSubnodes(
                     Vec<ImmId>{parent->subnodes.begin(), parent->subnodes.end()});
-                AST_EDIT_MSG(fmt("Tree {} parent {}", tree, parent));
+                AST_EDIT_MSG(hstd::fmt("Tree {} parent {}", tree, parent));
 
                 reparentedSubnodes = edits.newSubnodes(reparentedSubnodes);
                 newParentSubnodes.insert(
@@ -193,7 +197,7 @@ ImmAstReplaceGroup org::imm::demoteSubtree(
 
                 auto update = setSubnodes(
                     parent, {newParentSubnodes.begin(), newParentSubnodes.end()}, ctx);
-                AST_EDIT_MSG(fmt("Update subnode list {}", update));
+                AST_EDIT_MSG(hstd::fmt("Update subnode list {}", update));
                 edits.incl(update);
             }
         }
@@ -239,7 +243,8 @@ Opt<ImmAstReplace> org::imm::moveSubnode(
     subnodes = subnodes.insert(targetPosition, inserted);
 
     AST_EDIT_MSG(
-        fmt("Move subnodes {}[{} + {} => {}] -> {} -> {}",
+        hstd::fmt(
+            "Move subnodes {}[{} + {} => {}] -> {} -> {}",
             node,
             position,
             offset,
@@ -296,7 +301,7 @@ ImmAstReplace org::imm::replaceNode(
     ImmAdapter const&  target,
     ImmId const&       value,
     ImmAstEditContext& ctx) {
-    AST_EDIT_MSG(fmt("Replace adapter {} -> {}", target, value));
+    AST_EDIT_MSG(hstd::fmt("Replace adapter {} -> {}", target, value));
     return ImmAstReplace{
         .original = target.uniq(),
         .replaced = target.uniq().update(value),
@@ -347,11 +352,12 @@ bool recMatches(PathIter condition, ImmAdapter node, int depth, Ctx ctx) {
     if (ctx.can_visit(node)) {
         ctx.visit(node);
     } else {
-        ctx.sel->message(fmt("Cannot visit adapter {}", node));
+        ctx.sel->message(hstd::fmt("Cannot visit adapter {}", node));
         return false;
     }
     ctx.sel->message(
-        fmt("condition={} (@{}/{}) node={}",
+        hstd::fmt(
+            "condition={} (@{}/{}) node={}",
             condition->debug.value_or("<?>"),
             std::distance(ctx.sel->path.begin(), condition),
             ctx.sel->path.high(),
@@ -359,7 +365,8 @@ bool recMatches(PathIter condition, ImmAdapter node, int depth, Ctx ctx) {
     auto __scope = ctx.sel->begin_scope();
 
     if (ctx.maxDepth && ctx.maxDepth.value() < depth) {
-        ctx.sel->message(fmt("maxDepth {} < depth {}", ctx.maxDepth.value(), depth));
+        ctx.sel->message(
+            hstd::fmt("maxDepth {} < depth {}", ctx.maxDepth.value(), depth));
 
         return false;
     }
@@ -409,12 +416,13 @@ bool recMatches(PathIter condition, ImmAdapter node, int depth, Ctx ctx) {
                 case OrgSelectorLink::Kind::FieldName: {
                     auto const& name = std::get<OrgSelectorLink::FieldName>(
                         condition->link->data);
-                    ctx.sel->message(fmt("link field name '{}'", name.name));
+                    ctx.sel->message(hstd::fmt("link field name '{}'", name.name));
 
                     for (auto const& sub : node.getAllSubnodes(node.path)) {
                         auto drop = sub.flatPath().dropPrefix(node.flatPath());
                         ctx.sel->message(
-                            fmt("Subnode {} on path {} prefix {} drop {}",
+                            hstd::fmt(
+                                "Subnode {} on path {} prefix {} drop {}",
                                 sub.id,
                                 sub.flatPath(),
                                 node.flatPath(),
@@ -434,7 +442,8 @@ bool recMatches(PathIter condition, ImmAdapter node, int depth, Ctx ctx) {
 
         if (isMatch && condition->isTarget) {
             ctx.sel->message(
-                fmt("node is matched and marked as target\n{}",
+                hstd::fmt(
+                    "node is matched and marked as target\n{}",
                     node.treeRepr(
                             org::imm::ImmAdapter::TreeReprConf{
                                 .withAuxFields = true,
@@ -493,7 +502,9 @@ void OrgDocumentSelector::searchSubtreePlaintextTitle(
                     Vec<Str> plaintext = flatWords(tree.value().at(
                         imm::ImmReflFieldId::FromTypeField<imm::ImmSubtree>(
                             &imm::ImmSubtree::title)));
-                    message(fmt("{} == {} -> {}", plaintext, title, plaintext == title));
+                    message(
+                        hstd::fmt(
+                            "{} == {} -> {}", plaintext, title, plaintext == title));
 
                     return OrgSelectorResult{
                         .isMatching = title == plaintext,
@@ -505,7 +516,7 @@ void OrgDocumentSelector::searchSubtreePlaintextTitle(
                     };
                 }
             },
-            .debug    = fmt("HasSubtreePlaintextTitle:{}", title),
+            .debug    = hstd::fmt("HasSubtreePlaintextTitle:{}", title),
             .link     = link,
             .isTarget = isTarget,
         });
@@ -538,7 +549,7 @@ void OrgDocumentSelector::searchSubtreeId(
                     return OrgSelectorResult{.isMatching = false};
                 }
             },
-            .debug    = fmt("HasSubtreeId:{}", id),
+            .debug    = hstd::fmt("HasSubtreeId:{}", id),
             .link     = link,
             .isTarget = isTarget,
         });
@@ -555,7 +566,7 @@ void OrgDocumentSelector::searchAnyKind(
                     .isMatching = kinds.contains(node->getKind()),
                 };
             },
-            .debug    = fmt("HasKind:{}", kinds),
+            .debug    = hstd::fmt("HasKind:{}", kinds),
             .link     = link,
             .isTarget = isTarget,
         });

--- a/src/haxorg/imm/ImmOrgGraph.cpp
+++ b/src/haxorg/imm/ImmOrgGraph.cpp
@@ -20,6 +20,7 @@
 #include <haxorg/serde/SemOrgSerde.hpp>
 #include <haxorg/serde/SemOrgSerdeDeclarations.hpp>
 #include <hstd/stdlib/MapFormatter.hpp>
+#include <hstd/stdlib/SetFormatter.hpp>
 
 using namespace org::graph;
 using namespace hstd;

--- a/src/haxorg/imm/ImmOrgGraph.cpp
+++ b/src/haxorg/imm/ImmOrgGraph.cpp
@@ -458,7 +458,8 @@ Vec<MapLinkResolveResult> org::graph::getResolveTarget(
 
             default: {
                 throw logic_unreachable_error::init(
-                    fmt("Unhandled link kind '{}'", link_adapter->target.getKind()));
+                    hstd::fmt(
+                        "Unhandled link kind '{}'", link_adapter->target.getKind()));
             }
         }
     }
@@ -767,7 +768,8 @@ gv::Record MapGraph::GvConfig::getNodeLabel(
     if (node->loc || file) {
         rec.setEscaped(
             "Loc",
-            fmt("{}:{}:{} @ {}",
+            hstd::fmt(
+                "{}:{}:{} @ {}",
                 node->loc->column,
                 node->loc->line,
                 node->loc->pos,
@@ -781,8 +783,9 @@ gv::Record MapGraph::GvConfig::getNodeLabel(
                                   .as<ImmLink>()
                                   .value();
             rec.setEscaped(
-                fmt("Unresolved link [{}]", unresolved.getLink().link.id),
-                fmt("{} {}",
+                hstd::fmt("Unresolved link [{}]", unresolved.getLink().link.id),
+                hstd::fmt(
+                    "{} {}",
                     val.target.getKind(),
                     std::visit(
                         [](auto const& d) -> std::string {
@@ -791,7 +794,7 @@ gv::Record MapGraph::GvConfig::getNodeLabel(
                         val.target.data)));
         } else {
             rec.setEscaped(
-                fmt("Unresolved radio [{}]", unresolved.getRadio().target.id),
+                hstd::fmt("Unresolved radio [{}]", unresolved.getRadio().target.id),
                 "radio target");
         }
     }

--- a/src/haxorg/imm/ImmOrgGraph.cpp
+++ b/src/haxorg/imm/ImmOrgGraph.cpp
@@ -19,6 +19,7 @@
 #include "hstd/stdlib/Debug.hpp"
 #include <haxorg/serde/SemOrgSerde.hpp>
 #include <haxorg/serde/SemOrgSerdeDeclarations.hpp>
+#include <hstd/stdlib/MapFormatter.hpp>
 
 using namespace org::graph;
 using namespace hstd;

--- a/src/haxorg/imm/ImmOrgGraph.hpp
+++ b/src/haxorg/imm/ImmOrgGraph.hpp
@@ -503,5 +503,5 @@ bool isMmapIgnored(org::imm::ImmAdapter const& n);
 
 
 template <>
-struct std::formatter<org::graph::MapGraph*>
+struct fmt::formatter<org::graph::MapGraph*>
     : hstd::std_format_ptr_as_value<org::graph::MapGraph> {};

--- a/src/haxorg/imm/ImmOrgStore.cpp
+++ b/src/haxorg/imm/ImmOrgStore.cpp
@@ -70,14 +70,14 @@ hstd::Opt<ImmAstReplace> ImmAstStore::setNode(
     auto ft = fmt1(target);
     auto fr = fmt1(replaced);
     auto w  = std::max(ft.size(), fr.size());
-    AST_EDIT_MSG(fmt("| Original ID:{:<{}} {}", ft, w, target.value<T>()));
-    AST_EDIT_MSG(fmt("| Replaced ID:{:<{}} {}", fr, w, value));
+    AST_EDIT_MSG(hstd::fmt("| Original ID:{:<{}} {}", ft, w, target.value<T>()));
+    AST_EDIT_MSG(hstd::fmt("| Replaced ID:{:<{}} {}", fr, w, value));
 
     ctx.updateTracking(target.id, false);
     ctx.updateTracking(result_node, true);
 
     auto dbg = [&](std::string section) {
-        AST_EDIT_MSG(fmt("{}", section));
+        AST_EDIT_MSG(hstd::fmt("{}", section));
         auto        __scope = ctx.debug()->begin_scope();
         auto const& imm     = ctx.ctx.lock()->currentTrack->parents;
         auto const& mut     = ctx.transientTrack.parents;
@@ -87,7 +87,8 @@ hstd::Opt<ImmAstReplace> ImmAstStore::setNode(
         for (auto const& [key, value] : mut) { keys.incl(key); }
         for (auto const& key : sorted(keys | rs::to<Vec>())) {
             AST_EDIT_MSG(
-                fmt("key {:<24} imm {:<32} mut {:<32}",
+                hstd::fmt(
+                    "key {:<24} imm {:<32} mut {:<32}",
                     fmt1(key),
                     imm.find(key) == nullptr ? "" : fmt1(imm.at(key)),
                     mut.find(key) == nullptr ? "" : fmt1(mut.at(key))));
@@ -106,7 +107,8 @@ hstd::Opt<ImmAstReplace> ImmAstStore::setNode(
 
     if (replaced == target.uniq()) {
         AST_EDIT_MSG(
-            fmt("Original and replaced have the same ID -- node value did "
+            hstd::fmt(
+                "Original and replaced have the same ID -- node value did "
                 "not change, no replacement action needed"));
         return std::nullopt;
     } else {
@@ -182,7 +184,8 @@ Opt<ImmAstReplace> setNewSubnodes(
                 auto fail_field = [&](int         line     = __builtin_LINE(),
                                       char const* function = __builtin_FUNCTION()) {
                     throw logic_unreachable_error::init(
-                        fmt("Field path {} refers to a non-ID field "
+                        hstd::fmt(
+                            "Field path {} refers to a non-ID field "
                             "and "
                             "cannot assigned",
                             field),
@@ -293,7 +296,7 @@ ImmAdapter getUpdateTarget(
     ImmAstReplaceGroup const& replace,
     ImmAstEditContext&        ctx) {
     Opt<ImmUniqId> edit = replace.map.get(node.uniq());
-    AST_EDIT_MSG(fmt("Node {} direct edit:{}", node.id, edit), "aux");
+    AST_EDIT_MSG(hstd::fmt("Node {} direct edit:{}", node.id, edit), "aux");
 
     // If there were no modifications to the original node, use its
     // direct subnodes. Otherwise, take a newer version of the node
@@ -308,10 +311,10 @@ UnorderedSet<ImmUniqId> getEditParents(
     UnorderedSet<ImmUniqId> editParents;
 
     for (auto const& act : replace.allReplacements()) {
-        AST_EDIT_MSG(fmt("Parent chain for", act.original));
+        AST_EDIT_MSG(hstd::fmt("Parent chain for", act.original));
         for (auto const& parent :
              ctx->adapt(act.original.value()).getParentChain(false)) {
-            AST_EDIT_MSG(fmt("> {}", parent.uniq()));
+            AST_EDIT_MSG(hstd::fmt("> {}", parent.uniq()));
             editParents.incl(parent.uniq());
         }
     }
@@ -320,7 +323,7 @@ UnorderedSet<ImmUniqId> getEditParents(
     if (AST_EDIT_TRACE()) {
         auto __scope = ctx.debug()->begin_scope();
         for (auto const& key : replace.allReplacements()) {
-            AST_EDIT_MSG(fmt("[{}] -> {}", key.original, key.replaced));
+            AST_EDIT_MSG(hstd::fmt("[{}] -> {}", key.original, key.replaced));
         }
     }
 
@@ -328,7 +331,7 @@ UnorderedSet<ImmUniqId> getEditParents(
     if (AST_EDIT_TRACE()) {
         auto __scope = ctx.debug()->begin_scope();
         for (auto const& key : sorted(replace.nodeReplaceMap.keys())) {
-            AST_EDIT_MSG(fmt("[{}] -> {}", key, replace.nodeReplaceMap.at(key)));
+            AST_EDIT_MSG(hstd::fmt("[{}] -> {}", key, replace.nodeReplaceMap.at(key)));
         }
     }
 
@@ -336,7 +339,7 @@ UnorderedSet<ImmUniqId> getEditParents(
     if (AST_EDIT_TRACE()) {
         auto __scope = ctx.debug()->begin_scope();
         for (auto const& key : sorted(editParents | rs::to<Vec>())) {
-            AST_EDIT_MSG(fmt("[{}]", key));
+            AST_EDIT_MSG(hstd::fmt("[{}]", key));
         }
     }
 
@@ -396,8 +399,11 @@ ImmId recurseUpdateSubnodes(
             | rv::transform([](org::imm::ImmAdapter const& it) -> ImmId { return it.id; })
             | rs::to<Vec>();
         if (flatUpdatedSubnodes == targetSubnodes) {
-            AST_EDIT_MSG(fmt(
-                "Updated subnodes for {} are the same as target {}", node, updateTarget));
+            AST_EDIT_MSG(
+                hstd::fmt(
+                    "Updated subnodes for {} are the same as target {}",
+                    node,
+                    updateTarget));
 
             result->replaced.set(
                 ImmAstReplace{
@@ -408,7 +414,8 @@ ImmId recurseUpdateSubnodes(
             return updateTarget.id;
         } else {
             AST_EDIT_MSG(
-                fmt("Updated subnodes changed: updated:{} != "
+                hstd::fmt(
+                    "Updated subnodes changed: updated:{} != "
                     "target({}):{}",
                     updatedSubnodes,
                     updateTarget,
@@ -425,11 +432,11 @@ ImmId recurseUpdateSubnodes(
         // was updated, return a new version, otherwise return the same
         // node.
         if (auto edit = replace.map.get(node.uniq()); edit) {
-            AST_EDIT_MSG(fmt("Replace {} -> {}", node.uniq(), *edit));
+            AST_EDIT_MSG(hstd::fmt("Replace {} -> {}", node.uniq(), *edit));
             result->replaced.incl({node.uniq(), *edit});
             return edit->id;
         } else {
-            AST_EDIT_MSG(fmt("No changes in {}", node), "aux");
+            AST_EDIT_MSG(hstd::fmt("No changes in {}", node), "aux");
             return node.id;
         }
     }
@@ -445,9 +452,9 @@ ImmAstReplaceEpoch::Ptr ImmAstStore::cascadeUpdate(
     UnorderedSet<ImmUniqId> editParents = getEditParents(replace, ctx);
 
     ImmAstReplaceEpoch::Ptr result = ImmAstReplaceEpoch::shared();
-    AST_EDIT_MSG(fmt("Main root {}", root));
+    AST_EDIT_MSG(hstd::fmt("Main root {}", root));
     result->root = recurseUpdateSubnodes(root, replace, ctx, editParents, result);
-    AST_EDIT_MSG(fmt("Replace {}", result->replaced));
+    AST_EDIT_MSG(hstd::fmt("Replace {}", result->replaced));
     return result;
 }
 
@@ -548,7 +555,7 @@ void ImmAstKindStore<T>::format(ColStream& os, std::string const& linePrefix) co
     for (auto const& id : ids) {
         if (!isFirst) { os << "\n"; }
         isFirst = false;
-        os << fmt("{}[{}]: {}", linePrefix, id.getReadableId(), values.at(id));
+        os << hstd::fmt("{}[{}]: {}", linePrefix, id.getReadableId(), values.at(id));
     }
 }
 
@@ -556,7 +563,7 @@ void ImmAstKindStore<T>::format(ColStream& os, std::string const& linePrefix) co
 void ImmAstStore::format(ColStream& os, std::string const& prefix) const {
 #define _kind(__Kind)                                                                    \
     if (!store##__Kind.empty()) {                                                        \
-        os << fmt(                                                                       \
+        os << hstd::fmt(                                                                 \
             "\n{0}[{1:-<16}] {2:016X}\n", prefix, #__Kind, u64(OrgSemKind::__Kind));     \
         store##__Kind.format(os, prefix + "  ");                                         \
     }
@@ -566,7 +573,7 @@ void ImmAstStore::format(ColStream& os, std::string const& prefix) const {
 }
 
 void ImmAstContext::format(ColStream& os, std::string const& prefix) const {
-    os << fmt("{}ImmAstStore\n", prefix);
+    os << hstd::fmt("{}ImmAstStore\n", prefix);
     store->format(os, prefix + "  ");
 }
 
@@ -875,7 +882,8 @@ ImmId_t imm::ImmAstKindStore<ImmType>::add(SemId_t data, ImmAstEditContext& ctx)
     using SemType = imm_to_sem_map<ImmType>::sem_type;
     if (!data->is(SemType::staticKind)) {
         throw store_error::init(
-            fmt("Cannot create store value of kind {} from node of kind {}",
+            hstd::fmt(
+                "Cannot create store value of kind {} from node of kind {}",
                 ImmType::staticKind,
                 data->getKind()));
     }

--- a/src/haxorg/imm/ImmOrgStore.cpp
+++ b/src/haxorg/imm/ImmOrgStore.cpp
@@ -18,6 +18,7 @@
 #include <hstd/stdlib/OptFormatter.hpp>
 #include <hstd/stdlib/MapFormatter.hpp>
 #include <haxorg/imm/ImmOrgAdapter.hpp>
+#include <hstd/stdlib/PairFormatter.hpp>
 
 using namespace org;
 using namespace org::imm;

--- a/src/haxorg/lexbase/AstSpec.hpp
+++ b/src/haxorg/lexbase/AstSpec.hpp
@@ -141,8 +141,8 @@ struct AstRange {
 
 
 template <typename Name>
-struct fmt::formatter<org::parse::AstRange<Name>> : fmt::formatter<std::string> {
-
+struct fmt::formatter<org::parse::AstRange<Name>> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(org::parse::AstRange<Name> const& p, fmt::format_context& ctx)
         const {
         switch (p.kind) {

--- a/src/haxorg/lexbase/AstSpec.hpp
+++ b/src/haxorg/lexbase/AstSpec.hpp
@@ -141,11 +141,10 @@ struct AstRange {
 
 
 template <typename Name>
-struct std::formatter<org::parse::AstRange<Name>> : std::formatter<std::string> {
-    template <typename FormatContext>
-    FormatContext::iterator format(
-        org::parse::AstRange<Name> const& p,
-        FormatContext&                    ctx) const {
+struct fmt::formatter<org::parse::AstRange<Name>> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(org::parse::AstRange<Name> const& p, fmt::format_context& ctx)
+        const {
         switch (p.kind) {
             case org::parse::AstRangeKind::Point: {
                 hstd::fmt_ctx(p.idx, ctx);
@@ -544,7 +543,7 @@ struct AstSpec {
         auto diff = all - visited;
         if (!diff.empty()) {
             throw FieldAccessError(
-                std::format(
+                fmt::format(
                     "Indices missing from the field description {} are "
                     "not "
                     "covered in spec for node {}",
@@ -662,7 +661,7 @@ struct AstSpec {
         hstd::Opt<hstd::Slice<int>> slice,
         AstRange<Name> const&       range) const {
         return FieldAccessError::init(
-            std::format(
+            fmt::format(
                 "Range {} for node kind {} was resolved into slice {} "
                 "(required ast range is {})",
                 hstd::fmt1(name),

--- a/src/haxorg/lexbase/ErrorsFormatter.hpp
+++ b/src/haxorg/lexbase/ErrorsFormatter.hpp
@@ -5,8 +5,8 @@
 
 
 template <>
-struct fmt::formatter<org::parse::SourceLoc> : fmt::formatter<std::string> {
-
+struct fmt::formatter<org::parse::SourceLoc> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(org::parse::SourceLoc const& p, fmt::format_context& ctx)
         const {
         hstd::fmt_ctx(p.line, ctx);

--- a/src/haxorg/lexbase/ErrorsFormatter.hpp
+++ b/src/haxorg/lexbase/ErrorsFormatter.hpp
@@ -5,9 +5,9 @@
 
 
 template <>
-struct std::formatter<org::parse::SourceLoc> : std::formatter<std::string> {
-    template <typename FormatContext>
-    FormatContext::iterator format(org::parse::SourceLoc const& p, FormatContext& ctx)
+struct fmt::formatter<org::parse::SourceLoc> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(org::parse::SourceLoc const& p, fmt::format_context& ctx)
         const {
         hstd::fmt_ctx(p.line, ctx);
         hstd::fmt_ctx(":", ctx);

--- a/src/haxorg/lexbase/Lexer.hpp
+++ b/src/haxorg/lexbase/Lexer.hpp
@@ -145,9 +145,9 @@ struct LexerCommon {
                 if (os.colored) {
                     os << " "
                        << styledUnicodeMapping(
-                              std::format("{}", t.kind), hstd::AsciiStyle::Italic);
+                              fmt::format("{}", t.kind), hstd::AsciiStyle::Italic);
                 } else {
-                    os << " " << std::format("{}", t.kind);
+                    os << " " << fmt::format("{}", t.kind);
                 }
                 format(os, t);
             }
@@ -430,11 +430,11 @@ struct Lexer : public LexerCommon<K, V> {
 
 
 template <typename K, typename V>
-struct std::formatter<org::parse::LexerCommon<K, V>> : std::formatter<std::string> {
-    template <typename FormatContext>
-    FormatContext::iterator format(
+struct fmt::formatter<org::parse::LexerCommon<K, V>> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(
         org::parse::LexerCommon<K, V> const& p,
-        FormatContext&                       ctx) const {
+        fmt::format_context&                 ctx) const {
         return ::hstd::fmt_ctx(
             p.printToString([](hstd::ColStream&, org::parse::Token<K, V> const&) {}),
             ctx);

--- a/src/haxorg/lexbase/Lexer.hpp
+++ b/src/haxorg/lexbase/Lexer.hpp
@@ -430,8 +430,8 @@ struct Lexer : public LexerCommon<K, V> {
 
 
 template <typename K, typename V>
-struct fmt::formatter<org::parse::LexerCommon<K, V>> : fmt::formatter<std::string> {
-
+struct fmt::formatter<org::parse::LexerCommon<K, V>> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(
         org::parse::LexerCommon<K, V> const& p,
         fmt::format_context&                 ctx) const {

--- a/src/haxorg/lexbase/Node.cpp
+++ b/src/haxorg/lexbase/Node.cpp
@@ -116,14 +116,16 @@ typename NodeGroup<N, K, V, M>::Id NodeGroup<N, K, V, M>::subnode(Id node, int i
         }
 
         throw hstd::range_error::init(
-            fmt("Could not get subnode with index {} for node with id {} "
+            hstd::fmt(
+                "Could not get subnode with index {} for node with id {} "
                 "-- it contains only {} items",
                 index,
                 node.getUnmasked(),
                 i));
     } else {
         throw hstd::range_error::init(
-            fmt("Node {} of kind {} does not have subnode range", node, at(node).kind));
+            hstd::fmt(
+                "Node {} of kind {} does not have subnode range", node, at(node).kind));
     }
 }
 
@@ -157,7 +159,7 @@ void NodeGroup<N, K, V, M>::treeRepr(
     }
 
     int const startPosition = os.position;
-    os << repeat("  ", level) << std::format("{}", at(node).kind);
+    os << repeat("  ", level) << fmt::format("{}", at(node).kind);
 
     if (conf.customWrite) {
         hstd::ColStream tmp;
@@ -168,12 +170,14 @@ void NodeGroup<N, K, V, M>::treeRepr(
         os.write_indented_after_first(split, os.position - startPosition);
     }
 
-    if (conf.withSubnodeIdx) { os << os.cyan() << fmt("[{}]", subnodeIdx) << os.end(); }
+    if (conf.withSubnodeIdx) {
+        os << os.cyan() << hstd::fmt("[{}]", subnodeIdx) << os.end();
+    }
 
-    if (conf.withTreeMask) { os << fmt(" MASK:{}", node.getMask()); }
+    if (conf.withTreeMask) { os << hstd::fmt(" MASK:{}", node.getMask()); }
 
     if (conf.withTreeId) {
-        os << " " << os.blue() << fmt("ID:{}", node.getUnmasked()) << os.end();
+        os << " " << os.blue() << hstd::fmt("ID:{}", node.getUnmasked()) << os.end();
     }
 
     if (at(node).isTerminal()) {
@@ -186,7 +190,7 @@ void NodeGroup<N, K, V, M>::treeRepr(
                << fmt1(at(tok).value) << os.end();
         }
     } else {
-        if (conf.withExt) { os << fmt(" EXT:{}", at(node).getExtent()); }
+        if (conf.withExt) { os << hstd::fmt(" EXT:{}", at(node).getExtent()); }
 
         auto [begin, end] = subnodesOf(node).value();
         int  idx          = 0;

--- a/src/haxorg/lexbase/Node.hpp
+++ b/src/haxorg/lexbase/Node.hpp
@@ -150,8 +150,7 @@ struct fmt::formatter<org::parse::NodeId<N, K, V, M>> {
     hstd::fmt_iter format(
         org::parse::NodeId<N, K, V, M> const& p,
         fmt::format_context&                  ctx) const {
-        fmt::formatter<std::string> fmt;
-        return fmt.format(
+        return hstd::fmt_ctx(
             p.format(fmt::format("NodeId<{}>", hstd::demangle(typeid(N).name()))), ctx);
     }
 };
@@ -161,7 +160,6 @@ template <>
 struct fmt::formatter<std::monostate> {
     constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(std::monostate const& p, fmt::format_context& ctx) const {
-        fmt::formatter<std::string> fmt;
         return hstd::fmt_ctx("<std::monostate>", ctx);
     }
 };

--- a/src/haxorg/lexbase/Node.hpp
+++ b/src/haxorg/lexbase/Node.hpp
@@ -10,7 +10,6 @@
 #include <hstd/stdlib/ColText.hpp>
 
 #include <haxorg/lexbase/Token.hpp>
-#include <format>
 
 #include <variant>
 
@@ -146,31 +145,32 @@ struct hstd::value_domain<org::parse::NodeId<N, K, IdBase, MaskType>> {
 
 
 template <typename N, typename K, typename V, typename M>
-struct std::formatter<org::parse::NodeId<N, K, V, M>> : std::formatter<std::string> {
-    template <typename FormatContext>
-    FormatContext::iterator format(
+struct fmt::formatter<org::parse::NodeId<N, K, V, M>> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(
         org::parse::NodeId<N, K, V, M> const& p,
-        FormatContext&                        ctx) const {
-        std::formatter<std::string> fmt;
+        fmt::format_context&                  ctx) const {
+        fmt::formatter<std::string> fmt;
         return fmt.format(
-            p.format(std::format("NodeId<{}>", hstd::demangle(typeid(N).name()))), ctx);
+            p.format(fmt::format("NodeId<{}>", hstd::demangle(typeid(N).name()))), ctx);
     }
 };
 
 
 template <>
-struct std::formatter<std::monostate> : std::formatter<std::string> {
-    template <typename FormatContext>
-    FormatContext::iterator format(std::monostate const& p, FormatContext& ctx) const {
-        std::formatter<std::string> fmt;
+struct fmt::formatter<std::monostate> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(std::monostate const& p, fmt::format_context& ctx) const {
+        fmt::formatter<std::string> fmt;
         return hstd::fmt_ctx("<std::monostate>", ctx);
     }
 };
 
 template <typename N, typename K, typename V, typename M>
-struct std::formatter<org::parse::Node<N, K, V, M>> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(org::parse::Node<N, K, V, M> const& p, FormatContext& ctx) const {
+struct fmt::formatter<org::parse::Node<N, K, V, M>> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(org::parse::Node<N, K, V, M> const& p, fmt::format_context& ctx)
+        const {
         hstd::fmt_ctx("{", ctx);
         hstd::fmt_ctx(p.kind, ctx);
         if (p.isTerminal()) {

--- a/src/haxorg/lexbase/Node.hpp
+++ b/src/haxorg/lexbase/Node.hpp
@@ -145,8 +145,8 @@ struct hstd::value_domain<org::parse::NodeId<N, K, IdBase, MaskType>> {
 
 
 template <typename N, typename K, typename V, typename M>
-struct fmt::formatter<org::parse::NodeId<N, K, V, M>> : fmt::formatter<std::string> {
-
+struct fmt::formatter<org::parse::NodeId<N, K, V, M>> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(
         org::parse::NodeId<N, K, V, M> const& p,
         fmt::format_context&                  ctx) const {
@@ -158,8 +158,8 @@ struct fmt::formatter<org::parse::NodeId<N, K, V, M>> : fmt::formatter<std::stri
 
 
 template <>
-struct fmt::formatter<std::monostate> : fmt::formatter<std::string> {
-
+struct fmt::formatter<std::monostate> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(std::monostate const& p, fmt::format_context& ctx) const {
         fmt::formatter<std::string> fmt;
         return hstd::fmt_ctx("<std::monostate>", ctx);
@@ -167,8 +167,8 @@ struct fmt::formatter<std::monostate> : fmt::formatter<std::string> {
 };
 
 template <typename N, typename K, typename V, typename M>
-struct fmt::formatter<org::parse::Node<N, K, V, M>> : fmt::formatter<std::string> {
-
+struct fmt::formatter<org::parse::Node<N, K, V, M>> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(org::parse::Node<N, K, V, M> const& p, fmt::format_context& ctx)
         const {
         hstd::fmt_ctx("{", ctx);

--- a/src/haxorg/lexbase/Token.hpp
+++ b/src/haxorg/lexbase/Token.hpp
@@ -8,7 +8,6 @@
 #include <hstd/stdlib/Variant.hpp>
 #include <hstd/stdlib/Map.hpp>
 #include <hstd/stdlib/Func.hpp>
-#include <format>
 #include <hstd/stdlib/Opt.hpp>
 
 #include <haxorg/lexbase/Errors.hpp>
@@ -66,27 +65,27 @@ struct Token {
 
 
 template <hstd::StdFormattable K, typename V>
-struct std::formatter<org::parse::Token<K, V>> : std::formatter<std::string> {
-    template <typename FormatContext>
-    FormatContext::iterator format(org::parse::Token<K, V> const& p, FormatContext& ctx)
+struct fmt::formatter<org::parse::Token<K, V>> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(org::parse::Token<K, V> const& p, fmt::format_context& ctx)
         const {
-        std::formatter<std::string> fmt;
+        fmt::formatter<std::string> fmt;
         fmt.format("Token<", ctx);
-        std::formatter<K>{}.format(p.kind, ctx);
+        fmt::formatter<K>{}.format(p.kind, ctx);
         fmt.format(">(", ctx);
-        std::formatter<V>{}.format(p.value, ctx);
+        fmt::formatter<V>{}.format(p.value, ctx);
         return fmt.format(")", ctx);
     }
 };
 
 
 template <typename K, typename V>
-struct std::formatter<org::parse::TokenId<K, V>> : std::formatter<std::string> {
-    template <typename FormatContext>
-    typename FormatContext::iterator format(
+struct fmt::formatter<org::parse::TokenId<K, V>> : fmt::formatter<std::string> {
+
+    typename hstd::fmt_iter format(
         org::parse::TokenId<K, V> const& p,
-        FormatContext&                   ctx) const {
-        std::formatter<std::string>                      fmt;
+        fmt::format_context&             ctx) const {
+        fmt::formatter<std::string>                      fmt;
         typename org::parse::TokenId<K, V>::FormatConfig conf{
             .name = hstd::demangle(typeid(K).name())};
         return fmt.format(p.format(conf), ctx);

--- a/src/haxorg/lexbase/Token.hpp
+++ b/src/haxorg/lexbase/Token.hpp
@@ -65,29 +65,26 @@ struct Token {
 
 
 template <hstd::StdFormattable K, typename V>
-struct fmt::formatter<org::parse::Token<K, V>> : fmt::formatter<std::string> {
-
+struct fmt::formatter<org::parse::Token<K, V>> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(org::parse::Token<K, V> const& p, fmt::format_context& ctx)
         const {
-        fmt::formatter<std::string> fmt;
-        fmt.format("Token<", ctx);
-        fmt::formatter<K>{}.format(p.kind, ctx);
-        fmt.format(">(", ctx);
-        fmt::formatter<V>{}.format(p.value, ctx);
-        return fmt.format(")", ctx);
+        hstd::fmt_ctx("Token<", ctx);
+        hstd::fmt_ctx(p.kind, ctx);
+        hstd::fmt_ctx(">(", ctx);
+        hstd::fmt_ctx(p.value, ctx);
+        return hstd::fmt_ctx(")", ctx);
     }
 };
 
 
 template <typename K, typename V>
-struct fmt::formatter<org::parse::TokenId<K, V>> : fmt::formatter<std::string> {
-
-    typename hstd::fmt_iter format(
-        org::parse::TokenId<K, V> const& p,
-        fmt::format_context&             ctx) const {
-        fmt::formatter<std::string>                      fmt;
+struct fmt::formatter<org::parse::TokenId<K, V>> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+    hstd::fmt_iter format(org::parse::TokenId<K, V> const& p, fmt::format_context& ctx)
+        const {
         typename org::parse::TokenId<K, V>::FormatConfig conf{
             .name = hstd::demangle(typeid(K).name())};
-        return fmt.format(p.format(conf), ctx);
+        return hstd::fmt_ctx(p.format(conf), ctx);
     }
 };

--- a/src/haxorg/lexbase/TokenStore.hpp
+++ b/src/haxorg/lexbase/TokenStore.hpp
@@ -127,12 +127,14 @@ struct Tokenizer {
 
 
 template <hstd::StdFormattable K, hstd::StdFormattable V>
-struct std::formatter<org::parse::TokenGroup<K, V>> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(org::parse::TokenGroup<K, V> const& p, FormatContext& ctx) {
-        std::formatter<std::string> fmt;
+struct fmt::formatter<org::parse::TokenGroup<K, V>> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(
+        org::parse::TokenGroup<K, V> const& p,
+        fmt::format_context&                ctx) {
+        fmt::formatter<std::string> fmt;
         for (const auto& [idx, tok] : p.tokens.pairs()) {
-            fmt.format(std::format("{:<16}", idx), ctx);
+            fmt.format(fmt::format("{:<16}", idx), ctx);
             fmt.format(" | ", ctx);
             fmt.format(*tok, ctx);
             fmt.format("\n", ctx);

--- a/src/haxorg/lexbase/TokenStore.hpp
+++ b/src/haxorg/lexbase/TokenStore.hpp
@@ -132,14 +132,13 @@ struct fmt::formatter<org::parse::TokenGroup<K, V>> {
     hstd::fmt_iter format(
         org::parse::TokenGroup<K, V> const& p,
         fmt::format_context&                ctx) {
-        fmt::formatter<std::string> fmt;
         for (const auto& [idx, tok] : p.tokens.pairs()) {
-            fmt.format(fmt::format("{:<16}", idx), ctx);
-            fmt.format(" | ", ctx);
-            fmt.format(*tok, ctx);
-            fmt.format("\n", ctx);
+            hstd::fmt_ctx(fmt::format("{:<16}", idx), ctx);
+            hstd::fmt_ctx(" | ", ctx);
+            hstd::fmt_ctx(*tok, ctx);
+            hstd::fmt_ctx("\n", ctx);
         }
 
-        return fmt.format("", ctx);
+        return hstd::fmt_ctx("", ctx);
     }
 };

--- a/src/haxorg/lexbase/TokenStore.hpp
+++ b/src/haxorg/lexbase/TokenStore.hpp
@@ -127,8 +127,8 @@ struct Tokenizer {
 
 
 template <hstd::StdFormattable K, hstd::StdFormattable V>
-struct fmt::formatter<org::parse::TokenGroup<K, V>> : fmt::formatter<std::string> {
-
+struct fmt::formatter<org::parse::TokenGroup<K, V>> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(
         org::parse::TokenGroup<K, V> const& p,
         fmt::format_context&                ctx) {

--- a/src/haxorg/parse/OrgParser.cpp
+++ b/src/haxorg/parse/OrgParser.cpp
@@ -9,6 +9,7 @@
 #include <hstd/stdlib/OptFormatter.hpp>
 #include <haxorg/parse/OrgTypesFormatter.hpp>
 #include <hstd/stdlib/Ranges.hpp>
+#include <hstd/stdlib/VecFormatter.hpp>
 
 #pragma clang diagnostic error "-Wunused-result"
 

--- a/src/haxorg/parse/OrgParser.cpp
+++ b/src/haxorg/parse/OrgParser.cpp
@@ -389,13 +389,17 @@ void OrgParser::textFold(OrgLexer& lex) {
 
     Func<ParseResult()> aux;
     auto                _begin = [&](onk Kind) {
-        print(fmt("begin {}", Kind));
+        print(hstd::fmt("begin {}", Kind));
         int        startDepth = treeDepth();
         OrgTokenId startToken = pop(lex);
         start_no_guard(Kind);
         std::ignore = aux();
-        print(fmt(
-            "Started on {} exited on {} tok {}", startDepth, treeDepth(), startToken));
+        print(
+            hstd::fmt(
+                "Started on {} exited on {} tok {}",
+                startDepth,
+                treeDepth(),
+                startToken));
         // If the function returned earlier because the input has ended
         // before the markup opening was terminated it means there is no
         // correct markup in the text and it must be converted to the
@@ -405,7 +409,7 @@ void OrgParser::textFold(OrgLexer& lex) {
         // returning, the `aux(*)` will convert `Bold` into
         // `Punctuation(*)`
         if (startDepth < treeDepth()) {
-            print(fmt("Folding unclosed with token {}", lex.in->at(startToken)));
+            print(hstd::fmt("Folding unclosed with token {}", lex.in->at(startToken)));
             auto unclosed                   = group->pendingTrees.back();
             group->nodes.at(unclosed).kind  = onk::Punctuation;
             group->nodes.at(unclosed).value = startToken;
@@ -414,7 +418,7 @@ void OrgParser::textFold(OrgLexer& lex) {
     };
 
     auto _end = [&](onk Kind) {
-        print(fmt("end {}", Kind));
+        print(hstd::fmt("end {}", Kind));
         if (pending().kind == Kind) {
             end_impl();
             skip(lex);
@@ -424,7 +428,7 @@ void OrgParser::textFold(OrgLexer& lex) {
     };
 
     auto _unknown = [&](onk Kind) {
-        print(fmt("unknown {}", Kind));
+        print(hstd::fmt("unknown {}", Kind));
         if (pending().kind == Kind) {
             _end(Kind);
         } else {
@@ -619,7 +623,7 @@ Slice<OrgId> OrgParser::parseText(OrgLexer& lex) {
     print(hstd::fmt("Trace levels after text fold start:{} end:{}", treeStart, treeEnd));
 
     if (treeStart != treeEnd) {
-        auto msg = fmt(
+        auto msg = hstd::fmt(
             "Text fold created unbalanced tree - starting with depth {} "
             "ended up on depth {} on position {} (starting from {})",
             treeStart,
@@ -1134,7 +1138,8 @@ OrgParser::ParseResult OrgParser::parseVerbatimOrMonospace(OrgLexer& lex) {
     } else {
         if (TraceState) {
             print(
-                fmt("Reset monospace parse position. Removing tail at {}, "
+                hstd::fmt(
+                    "Reset monospace parse position. Removing tail at {}, "
                     "moving lexer from {} to {}",
                     startGuard->startId,
                     lex.getPos(),
@@ -1463,12 +1468,12 @@ OrgParser::ParseResult OrgParser::parseTextWrapCommand(OrgLexer& lex) {
     if (isDynamic) {
         hstd::replace_all(tmp, "begin", "end");
         Str endName = normalize(tmp);
-        print(fmt("Dynamic block, name {}", endName));
+        print(hstd::fmt("Dynamic block, name {}", endName));
         while (lex.can_search(Vec<otk>{otk::CmdPrefix, endTok}) && lex.hasNext(2)
                && normalize(lex.val(1).text) != endName) {
             SUB_PARSE(StmtListItem, lex);
             if (lex.at(BlockTerminator)) {
-                print(fmt("block terminator {}", lex));
+                print(hstd::fmt("block terminator {}", lex));
                 break;
             }
         }
@@ -1476,7 +1481,7 @@ OrgParser::ParseResult OrgParser::parseTextWrapCommand(OrgLexer& lex) {
         while (lex.can_search(Vec<otk>{otk::CmdPrefix, endTok})) {
             SUB_PARSE(StmtListItem, lex);
             if (lex.at(BlockTerminator)) {
-                print(fmt("block terminator {}", lex));
+                print(hstd::fmt("block terminator {}", lex));
                 break;
             }
         }
@@ -1641,7 +1646,7 @@ OrgParser::ParseResult OrgParser::parseSrc(OrgLexer& lex) {
                     }
                     default: {
                         throw fatalError(
-                            lex, fmt("Unhandled code parse token {}", lex.tok()));
+                            lex, hstd::fmt("Unhandled code parse token {}", lex.tok()));
                     }
                 }
             }
@@ -1727,7 +1732,8 @@ OrgParser::ParseResult OrgParser::parseListItem(OrgLexer& lex) {
             print("Sub-lexer reached end without header");
         } else {
             print(
-                fmt("Searched for double colon to {} tmp-pos {} lex-pos {}",
+                hstd::fmt(
+                    "Searched for double colon to {} tmp-pos {} lex-pos {}",
                     tmp.tok(),
                     tmp.pos,
                     lex.pos));
@@ -1772,7 +1778,7 @@ OrgParser::ParseResult OrgParser::parseList(OrgLexer& lex) {
     auto __trace = trace(lex);
     auto check   = start(onk::List);
 
-    print(fmt("{}", lex.tok()));
+    print(hstd::fmt("{}", lex.tok()));
 
     while (lex.at(ListStarts) || (lex.at(otk::LeadingSpace) && lex.at(ListStarts, +1))) {
         SUB_PARSE(ListItem, lex);
@@ -2424,7 +2430,7 @@ OrgParser::ParseResult OrgParser::parseLineCommand(OrgLexer& lex) {
 
 
         default: {
-            throw fatalError(lex, fmt("Unhandled command kind {}", lex.kind(+1)));
+            throw fatalError(lex, hstd::fmt("Unhandled command kind {}", lex.kind(+1)));
         }
     }
 
@@ -2583,7 +2589,7 @@ void assertValidStructure(OrgNodeGroup* group, OrgId id) {
         auto& g = *group;
         LOGIC_ASSERTION_CHECK_FMT(g.nodes.contains(top), "");
         auto fmt_id = [&](Id const& id) {
-            return fmt("{} {}", id.format(), g.at(id).kind);
+            return hstd::fmt("{} {}", id.format(), g.at(id).kind);
         };
         if (g.at(top).isTerminal() || g.at(top).isMono()) { return; }
 
@@ -2698,7 +2704,8 @@ OrgId extendSubtreeTrailsImpl(OrgParser* parser, OrgId id, int level) {
 
                 if (parser->TraceState) {
                     parser->print(
-                        fmt("Found nested subtree tree={} stmt={} "
+                        hstd::fmt(
+                            "Found nested subtree tree={} stmt={} "
                             "tree-extend={} stmt-extend={}",
                             tree.format(),
                             stmt.format(),

--- a/src/haxorg/parse/OrgParserReport.cpp
+++ b/src/haxorg/parse/OrgParserReport.cpp
@@ -108,13 +108,13 @@ void OrgParser::report(Report const& in) {
 
         auto printSourceLoc = [&]() {
             if (in.function) { os << " " << in.function; }
-            os << fmt(":{}", in.line);
+            os << hstd::fmt(":{}", in.line);
         };
 
         auto printNode = [&]() {
             auto id = in.node.value();
             if (in.node && !in.node.value().isNil()) {
-                os << std::format(
+                os << fmt::format(
                     "{} {} ID:{} @{}",
                     (in.kind == ReportKind::StartNode ? "+" : "-"),
                     group->at(id).kind,
@@ -151,14 +151,14 @@ void OrgParser::report(Report const& in) {
 
             case ReportKind::Print: {
                 if (in.msg) { os << "  " << *in.msg; }
-                os << std::format(" @{}", in.line);
+                os << fmt::format(" @{}", in.line);
                 printTokens();
                 break;
             }
 
             case ReportKind::AddToken: {
                 auto id = in.node.value();
-                os << std::format(
+                os << fmt::format(
                     "  add {} ID:{} @{} with '{}'",
                     group->at(id).kind,
                     id.getUnmasked(),
@@ -174,7 +174,7 @@ void OrgParser::report(Report const& in) {
                 printNode();
                 auto id = in.node.value();
                 if (in.kind == ReportKind::EndNode) {
-                    os << " ext=" << std::format("{}", group->at(id).getExtent());
+                    os << " ext=" << fmt::format("{}", group->at(id).getExtent());
                 }
                 if (in.msg && !in.msg->empty()) { os << " " << *in.msg; }
                 break;
@@ -182,7 +182,7 @@ void OrgParser::report(Report const& in) {
 
             case ReportKind::EnterParse:
             case ReportKind::LeaveParse: {
-                os << std::format(
+                os << fmt::format(
                     "{} [{}] ",
                     in.kind == ReportKind::EnterParse ? ">" : "<",
                     treeDepth())

--- a/src/haxorg/parse/OrgParserUtils.cpp
+++ b/src/haxorg/parse/OrgParserUtils.cpp
@@ -250,7 +250,7 @@ OrgParser::ParseResult OrgParser::expect(
     if (at(lex, item)) {
         return ParseOk{};
     } else {
-        auto msg = fmt(
+        auto msg = hstd::fmt(
             "{}: Expected token {} {} but got '{}'",
             line,
             item,
@@ -282,7 +282,7 @@ OrgParser::LexResult OrgParser::pop(
     int                line,
     char const*        function) {
     if (tok) { BOOST_OUTCOME_TRY(expect(lex, *tok, std::nullopt, line, function)); }
-    if (TraceState) { print(fmt("pop {}", lex.tok()), &lex, line, function); }
+    if (TraceState) { print(hstd::fmt("pop {}", lex.tok()), &lex, line, function); }
     return lex.pop();
 }
 
@@ -296,7 +296,7 @@ OrgParser::ParseResult OrgParser::skip(
 
     if (item) { BOOST_OUTCOME_TRY(expect(lex, *item, message, line, function)); }
 
-    if (TraceState) { print(fmt("skip {}", lex.tok()), &lex, line, function); }
+    if (TraceState) { print(hstd::fmt("skip {}", lex.tok()), &lex, line, function); }
 
     lex.next();
     return ParseOk{};
@@ -352,7 +352,8 @@ parse_error OrgParser::fatalError(
     Opt<OrgToken> tok = lex.hasNext(-1) ? Opt<OrgToken>{lex.tok(-1)} : std::nullopt;
 
     return parse_error::init(
-        fmt("{} {} at {} in (prev: {}) {}",
+        hstd::fmt(
+            "{} {} at {} in (prev: {}) {}",
             msg,
             lex.finished()
                 ? (lex.lastToken ? fmt1(lex.lastToken.value()) : "<lexer-finished>")

--- a/src/haxorg/parse/OrgTokenizer.cpp
+++ b/src/haxorg/parse/OrgTokenizer.cpp
@@ -11,6 +11,7 @@
 #include <haxorg/sem/perfetto_org.hpp>
 #include <hstd/stdlib/Enumerate.hpp>
 #include <hstd/stdlib/Formatter.hpp>
+#include <hstd/stdlib/VecFormatter.hpp>
 
 using namespace hstd;
 using namespace org::parse;
@@ -80,9 +81,9 @@ OrgFill fill(OrgLexer& lex) {
 }
 
 template <typename T>
-struct std::formatter<rs::subrange<T>> : std::formatter<std::string> {
-    template <typename FormatContext>
-    FormatContext::iterator format(rs::subrange<T> const& p, FormatContext& ctx) const {
+struct fmt::formatter<rs::subrange<T>> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(rs::subrange<T> const& p, fmt::format_context& ctx) const {
         fmt_ctx("[", ctx);
         bool first = true;
         for (auto begin = rs::begin(p); begin != rs::end(p); begin = std::next(begin)) {
@@ -159,7 +160,7 @@ struct RecombineState {
 
 
     void next(OrgLexer& lex, int line = __builtin_LINE()) {
-        x_report(Print, .with_line(line).with_msg(fmt("next {}", lex.tok())));
+        x_report(Print, .with_line(line).with_msg(hstd::fmt("next {}", lex.tok())));
         lex.next();
     }
 
@@ -171,7 +172,7 @@ struct RecombineState {
 
 
     void skip(OrgLexer& lex, OrgTokenKind kind, int line = __builtin_LINE()) {
-        x_report(Print, .with_line(line).with_msg(fmt("skip {}", lex.tok())));
+        x_report(Print, .with_line(line).with_msg(hstd::fmt("skip {}", lex.tok())));
         lex.skip(kind);
     }
 
@@ -180,13 +181,14 @@ struct RecombineState {
         x_report(
             Push,
             .with_id(res).with_line(line).with_msg(
-                fmt("add {} from {}", __to, lex.tok())));
+                hstd::fmt("add {} from {}", __to, lex.tok())));
         return res;
     }
 
     void pop(Opt<OrgTokenKind> expected = std::nullopt, int line = __builtin_LINE()) {
         auto res = d->out->add(lex.tok());
-        x_report(Push, .with_id(res).with_line(line).with_msg(fmt("pop {}", lex.tok())));
+        x_report(
+            Push, .with_id(res).with_line(line).with_msg(hstd::fmt("pop {}", lex.tok())));
         if (expected) {
             lex.skip(*expected);
         } else {
@@ -199,7 +201,7 @@ struct RecombineState {
         x_report(
             Push,
             .with_id(res).with_line(line).with_msg(
-                fmt("add {} from {}", tok, lex.tok())));
+                hstd::fmt("add {} from {}", tok, lex.tok())));
         return res;
     }
 
@@ -211,7 +213,7 @@ struct RecombineState {
         x_report(
             Push,
             .with_id(res).with_line(line).with_msg(
-                fmt("pop {} from {}", __to, lex.tok())));
+                hstd::fmt("pop {} from {}", __to, lex.tok())));
         if (expected) {
             lex.skip(*expected);
         } else {
@@ -229,7 +231,7 @@ struct RecombineState {
         x_report(
             Push,
             .with_id(res).with_line(line).with_msg(
-                fmt("fake {} from {}", __to, lex.tok())));
+                hstd::fmt("fake {} from {}", __to, lex.tok())));
         return res;
     }
 
@@ -238,7 +240,7 @@ struct RecombineState {
         x_report(
             Push,
             .with_id(res).with_line(line).with_msg(
-                fmt("fake {} from {}", __to, lex.tok())));
+                hstd::fmt("fake {} from {}", __to, lex.tok())));
         return res;
     }
 
@@ -290,7 +292,8 @@ struct RecombineState {
 
         if (TraceState) {
             print(
-                fmt("prev kind {} next kind {} prev_empty={} next_empty={}",
+                hstd::fmt(
+                    "prev kind {} next kind {} prev_empty={} next_empty={}",
                     prev ? prev->kind : otk::Unknown,
                     next ? next->kind : otk::Unknown,
                     prev_empty,
@@ -664,7 +667,8 @@ struct LineToken {
                 kind = *next;
             } else {
                 throw tokenizer_error::init(
-                    fmt("Unknown line command kind mapping {}, {}",
+                    hstd::fmt(
+                        "Unknown line command kind mapping {}, {}",
                         tokens.at(tokensOffset + 1),
                         tokens));
             }
@@ -674,7 +678,8 @@ struct LineToken {
             kind = Kind::BlockClose;
         } else {
             throw tokenizer_error::init(
-                fmt("Expected line command or closing block, but got {}", current.kind));
+                hstd::fmt(
+                    "Expected line command or closing block, but got {}", current.kind));
         }
     }
 
@@ -852,7 +857,9 @@ struct TokenVisitor {
             if (line_end.contains(it->kind)) {
                 auto span = IteratorSpan(start, std::next(it));
                 auto line = LineToken{span};
-                if (TraceState) { d->print(lex, fmt("{} {}", line.kind, line.tokens)); }
+                if (TraceState) {
+                    d->print(lex, hstd::fmt("{} {}", line.kind, line.tokens));
+                }
                 lines.push_back(line);
                 start = std::next(it);
             }
@@ -860,7 +867,7 @@ struct TokenVisitor {
 
         if (start != tokens->end()) {
             auto span = IteratorSpan(start, tokens->end());
-            if (TraceState) { d->print(lex, fmt("{}", span)); }
+            if (TraceState) { d->print(lex, hstd::fmt("{}", span)); }
             lines.push_back(LineToken{span});
         }
 
@@ -876,7 +883,7 @@ struct TokenVisitor {
             auto __scope  = d->begin_scope();
             auto end      = lines.end();
             auto nextline = [&]() { ++it; };
-            if (TraceState) { d->message(fmt("{} {}", it->kind, it->tokens)); }
+            if (TraceState) { d->message(hstd::fmt("{} {}", it->kind, it->tokens)); }
 
             auto start = it;
             switch (start->kind) {
@@ -939,7 +946,7 @@ struct TokenVisitor {
 
                 default: {
                     throw tokenizer_error::init(
-                        fmt("Unhandled line kind {} {}", start->kind, it->tokens));
+                        hstd::fmt("Unhandled line kind {} {}", start->kind, it->tokens));
                     return std::nullopt;
                 }
             }
@@ -982,7 +989,8 @@ struct GroupVisitorState {
         if (TraceState) {
             d->print(
                 lex,
-                fmt("    [{:<3}] fake  {:<48} indents {:<32}",
+                hstd::fmt(
+                    "    [{:<3}] fake  {:<48} indents {:<32}",
                     idx.getIndex(),
                     fmt1(kind),
                     fmt1(indentStack)),
@@ -1000,7 +1008,8 @@ struct GroupVisitorState {
         if (TraceState) {
             d->print(
                 lex,
-                fmt("    [{:<3}] token {:<48} indents {:<32}",
+                hstd::fmt(
+                    "    [{:<3}] token {:<48} indents {:<32}",
                     idx.getIndex(),
                     fmt1(tok),
                     fmt1(indentStack)),
@@ -1018,7 +1027,7 @@ struct GroupVisitorState {
         if (TraceState) {
             d->print(
                 lex,
-                fmt("  ADD LINE: indent={} kind={}", line.indent, line.kind),
+                hstd::fmt("  ADD LINE: indent={} kind={}", line.indent, line.kind),
                 code_line,
                 function);
         }
@@ -1081,7 +1090,8 @@ struct GroupVisitorState {
                                   char const* function = __builtin_FUNCTION()) {
                 if (TraceState) {
                     print1(
-                        fmt("indent: {}, gr.indent(): {} index {}",
+                        hstd::fmt(
+                            "indent: {}, gr.indent(): {} index {}",
                             ind,
                             gr.indent(),
                             gr_index),
@@ -1258,12 +1268,13 @@ struct GroupVisitorState {
         char const*      function  = __builtin_FUNCTION()) {
         if (TraceState) {
             print1(
-                fmt("[{}] line:{} indent={}{}",
+                hstd::fmt(
+                    "[{}] line:{} indent={}{}",
                     prefix,
                     line.kind,
                     line.indent,
                     line.kind == LK::ListItem
-                        ? fmt(" ListBreak:{}", line.isListBreakingItem())
+                        ? hstd::fmt(" ListBreak:{}", line.isListBreakingItem())
                         : ""),
                 level,
                 code_line,
@@ -1271,7 +1282,7 @@ struct GroupVisitorState {
 
             for (int token_idx = 0; token_idx < line.tokens.size(); ++token_idx) {
                 print1(
-                    fmt("[{}] {}", token_idx, line.tokens.at(token_idx)),
+                    hstd::fmt("[{}] {}", token_idx, line.tokens.at(token_idx)),
                     level + 1,
                     code_line,
                     function);
@@ -1286,7 +1297,8 @@ struct GroupVisitorState {
                 auto const& gr = groups.at(gr_index);
                 if (TraceState) {
                     print1(
-                        fmt("[{}] group:{} indent {}", gr_index, gr.kind, gr.indent()),
+                        hstd::fmt(
+                            "[{}] group:{} indent {}", gr_index, gr.kind, gr.indent()),
                         level);
                 }
 

--- a/src/haxorg/parse/OrgTokenizer.cpp
+++ b/src/haxorg/parse/OrgTokenizer.cpp
@@ -13,6 +13,7 @@
 #include <hstd/stdlib/Formatter.hpp>
 #include <hstd/stdlib/VecFormatter.hpp>
 
+
 using namespace hstd;
 using namespace org::parse;
 
@@ -81,8 +82,8 @@ OrgFill fill(OrgLexer& lex) {
 }
 
 template <typename T>
-struct fmt::formatter<rs::subrange<T>> : fmt::formatter<std::string> {
-
+struct fmt::formatter<rs::subrange<T>> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(rs::subrange<T> const& p, fmt::format_context& ctx) const {
         fmt_ctx("[", ctx);
         bool first = true;

--- a/src/haxorg/parse/OrgTokenizerReport.cpp
+++ b/src/haxorg/parse/OrgTokenizerReport.cpp
@@ -83,7 +83,7 @@ void OrgTokenizer::report(Report const& in) {
                 os << "    ";
                 if (in.msg) { os << *in.msg; }
                 if (in.subname) { os << ":" << *in.subname; }
-                os << fmt(" {}:{}", (in.function ? in.function : ""), in.line)
+                os << hstd::fmt(" {}:{}", (in.function ? in.function : ""), in.line)
                    << getLoc();
                 break;
             }
@@ -95,10 +95,10 @@ void OrgTokenizer::report(Report const& in) {
             case ReportKind::Push: {
                 if (in.id.isNil()) {
                     os << "  + buffer token " << fmt1(getLoc())
-                       << std::format("{}", in.tok.kind);
+                       << fmt::format("{}", in.tok.kind);
                 } else {
                     os << "  + add token " << fmt1(getLoc()) << fmt1(in.id.getIndex())
-                       << " " << std::format("{}", at(in.id).kind);
+                       << " " << fmt::format("{}", at(in.id).kind);
                 }
                 os << " @" << fg::Cyan << fmt1(in.line) << os.end();
                 if (in.msg) { os << " " << *in.msg; }

--- a/src/haxorg/parse/OrgTypesFormatter.hpp
+++ b/src/haxorg/parse/OrgTypesFormatter.hpp
@@ -5,9 +5,11 @@
 
 
 template <>
-struct std::formatter<org::parse::OrgNodeMono::Error> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(org::parse::OrgNodeMono::Error const& p, FormatContext& ctx) const {
+struct fmt::formatter<org::parse::OrgNodeMono::Error> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(
+        org::parse::OrgNodeMono::Error const& p,
+        fmt::format_context&                  ctx) const {
         if (p.box) {
             return hstd::fmt_ctx(*p.box, ctx);
         } else {

--- a/src/haxorg/parse/OrgTypesFormatter.hpp
+++ b/src/haxorg/parse/OrgTypesFormatter.hpp
@@ -5,8 +5,8 @@
 
 
 template <>
-struct fmt::formatter<org::parse::OrgNodeMono::Error> : fmt::formatter<std::string> {
-
+struct fmt::formatter<org::parse::OrgNodeMono::Error> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(
         org::parse::OrgNodeMono::Error const& p,
         fmt::format_context&                  ctx) const {

--- a/src/haxorg/sem/SemConvert.cpp
+++ b/src/haxorg/sem/SemConvert.cpp
@@ -242,7 +242,7 @@ Str get_text(
         return res;
     } else {
         throw convert_logic_error::init(
-            fmt("{} {} {}", function, line, a.treeRepr(false)));
+            hstd::fmt("{} {} {}", function, line, a.treeRepr(false)));
     }
 }
 
@@ -369,15 +369,17 @@ OrgConverter::ConvResult<SubtreeLog> OrgConverter::convertSubtreeLog(__args) {
     auto node_after = [&](Str const&    word,
                           SemSet const& target) -> Opt<sem::SemId<sem::Org>> {
         auto __trace = trace(a, "node_after");
-        print(fmt("Searching for '{}' after '{}' in {}", target, word, par0->subnodes));
+        print(
+            hstd::fmt(
+                "Searching for '{}' after '{}' in {}", target, word, par0->subnodes));
         for (int i = 0; i < par0.size(); ++i) {
             if (auto w = par0.at(i)->dyn_cast<sem::Leaf>();
                 w != nullptr && normalize(w->text) == word) {
-                print(fmt("[{}] = {}({})", i, w->getKind(), w->text));
+                print(hstd::fmt("[{}] = {}({})", i, w->getKind(), w->text));
                 auto offset = i + 1;
                 while (offset < par0.size()) {
                     auto t = par0.at(offset);
-                    print(fmt("[{}] = {}", offset, t->getKind()));
+                    print(hstd::fmt("[{}] = {}", offset, t->getKind()));
                     if ((SemSet{osk::Word} - target).contains(t->getKind())) {
                         goto found_search_limit;
                     } else if (target.contains(t->getKind())) {
@@ -499,7 +501,7 @@ OrgConverter::ConvResult<SubtreeLog> OrgConverter::convertSubtreeLog(__args) {
 
         } else if (words.has(0) && words.at(0) == "priority") {
             auto __trace = trace(a, "priority");
-            print(fmt("words {}", words));
+            print(hstd::fmt("words {}", words));
             Vec<SemId<Time>>     times      = filter_subnodes<Time>(par0, limit);
             Vec<SemId<BigIdent>> priorities = filter_subnodes<BigIdent>(par0, limit);
             auto                 priority   = Log::Priority{};
@@ -527,7 +529,7 @@ OrgConverter::ConvResult<SubtreeLog> OrgConverter::convertSubtreeLog(__args) {
                 priority.action = Log::Priority::Action::Removed;
             } else {
                 throw convert_logic_error::init(
-                    fmt("{} Unexpected priority log message structure", words));
+                    hstd::fmt("{} Unexpected priority log message structure", words));
             }
 
             if (auto on = time_after("on")) { priority.on = on.value()->getStaticTime(); }
@@ -663,13 +665,13 @@ Opt<SemId<ErrorGroup>> OrgConverter::convertPropertyList(SemId<Subtree>& tree, I
         get_text(one(a, N::Name)), CharSet{' ', ':'}, CharSet{':'});
     std::string name = normalize(basename);
 
-    auto __trace = trace(a, fmt("property-'{}' (base: '{}')", name, basename));
+    auto __trace = trace(a, hstd::fmt("property-'{}' (base: '{}')", name, basename));
 
     auto get_values_text = [&]() { return strip_space(get_text(one(a, N::Values))); };
 
     auto handled = [&](int         line     = __builtin_LINE(),
                        char const* function = __builtin_FUNCTION()) {
-        print(fmt("handled '{}'", name), line, function);
+        print(hstd::fmt("handled '{}'", name), line, function);
     };
 
 
@@ -703,8 +705,8 @@ Opt<SemId<ErrorGroup>> OrgConverter::convertPropertyList(SemId<Subtree>& tree, I
         handled();
         Property::HashtagDef def;
         auto                 par = convertParagraph(one(a, N::Values)).value();
-        print(fmt("{}", a.treeRepr()));
-        print(fmt("{}", ExporterTree::treeRepr(par).toString(false)));
+        print(hstd::fmt("{}", a.treeRepr()));
+        print(hstd::fmt("{}", ExporterTree::treeRepr(par).toString(false)));
         for (int i = 0; i < par.size(); ++i) {
             auto sub = par.at(i);
             if (sub->is(OrgSemKind::Space)) {
@@ -775,7 +777,7 @@ Opt<SemId<ErrorGroup>> OrgConverter::convertPropertyList(SemId<Subtree>& tree, I
                     MakeConvert(
                         a,
                         ErrorTable::UnexpectedCookieData,
-                        fmt("Unexpected cookie data parameter: {}", arg)));
+                        hstd::fmt("Unexpected cookie data parameter: {}", arg)));
             }
         }
 
@@ -822,7 +824,8 @@ Opt<SemId<ErrorGroup>> OrgConverter::convertPropertyList(SemId<Subtree>& tree, I
             result    = NamedProperty{prop};
         } else {
             throw convert_logic_error::init(
-                fmt("broken datetime or broken zone from value {} "
+                hstd::fmt(
+                    "broken datetime or broken zone from value {} "
                     "(datetime: '{}', zone: '{}')",
                     time,
                     datetime,
@@ -998,7 +1001,7 @@ OrgConverter::ConvResult<Subtree> OrgConverter::convertSubtree(__args) {
                     MakeConvert(
                         a,
                         ErrorTable::UnexpectedSubtreeTimeName,
-                        fmt("The value was '{}'", kind)));
+                        hstd::fmt("The value was '{}'", kind)));
             }
         }
     }
@@ -1257,7 +1260,7 @@ OrgConverter::ConvResult<Link> OrgConverter::convertLink(__args) {
     } else {
         Str protocol_raw = get_text(one(a, N::Protocol));
         Str protocol     = normalize(get_text(one(a, N::Protocol)));
-        print(fmt("Protocol is '{}', normalized {}", protocol_raw, protocol));
+        print(hstd::fmt("Protocol is '{}', normalized {}", protocol_raw, protocol));
         if (protocol == "http" || protocol == "https") {
             link->target = LinkTarget{
                 LinkTarget::Raw{.text = protocol + ":"_ss + getTarget()}};
@@ -1318,7 +1321,7 @@ OrgConverter::ConvResult<ListItem> OrgConverter::convertListItem(__args) {
         Str text = strip(
             get_text(one(a, N::Checkbox)), CharSet{'[', ' '}, CharSet{' ', ']'});
 
-        print(fmt("Normalized checkbox: {}", escape_literal(text)));
+        print(hstd::fmt("Normalized checkbox: {}", escape_literal(text)));
 
         if (text == "x" || text == "X") {
             item->checkbox = CheckboxState::Done;
@@ -1330,7 +1333,9 @@ OrgConverter::ConvResult<ListItem> OrgConverter::convertListItem(__args) {
             return SemError(
                 a,
                 MakeConvert(
-                    a, ErrorTable::UnexpectedCheckboxValue, fmt("got value '{}'", text)));
+                    a,
+                    ErrorTable::UnexpectedCheckboxValue,
+                    hstd::fmt("got value '{}'", text)));
         }
     }
 
@@ -2047,7 +2052,7 @@ OrgConverter::ConvResult<CmdInclude> OrgConverter::convertCmdInclude(__args) {
     auto              args    = convertAttrs(one(a, N::Args));
     include->path             = args.positional.items.at(0).getString();
 
-    if (TraceState) { print(fmt("args: {}", args)); }
+    if (TraceState) { print(hstd::fmt("args: {}", args)); }
 
     if (auto kind = args.positional.items.get(1)) {
         Str ks = kind.value().get().getString();
@@ -2134,17 +2139,17 @@ sem::AttrValue OrgConverter::convertAttr(__args) {
 
     if (one(a, N::Name).getKind() != onk::Empty) {
         result.name = lstrip(get_text(one(a, N::Name)), CharSet{':'});
-        print(fmt("Result name '{}'", result.name.value()));
+        print(hstd::fmt("Result name '{}'", result.name.value()));
     }
 
     if (one(a, N::Subname).getKind() != onk::Empty) {
         result.varname = get_text(one(a, N::Subname));
-        print(fmt("Result varname '{}'", result.varname.value()));
+        print(hstd::fmt("Result varname '{}'", result.varname.value()));
     }
 
     if (one(a, N::Value).getKind() == onk::RawText) {
         Str value = get_text(one(a, N::Value));
-        print(fmt("Text value is '{}'", value));
+        print(hstd::fmt("Text value is '{}'", value));
 
         if (value.starts_with('"') && value.ends_with('"')) {
             result.isQuoted = true;
@@ -2156,12 +2161,12 @@ sem::AttrValue OrgConverter::convertAttr(__args) {
             AttrValue::FileReference fr{};
             fr.file      = split.at(0);
             fr.reference = split.at(1);
-            print(fmt("Attribute is file reference {}", fr));
+            print(hstd::fmt("Attribute is file reference {}", fr));
             result.data = fr;
         } else {
             AttrValue::TextValue tv{};
             tv.value = value;
-            print(fmt("Attribute is text value {}", tv));
+            print(hstd::fmt("Attribute is text value {}", tv));
 
             result.data = tv;
         }
@@ -2173,7 +2178,7 @@ sem::AttrValue OrgConverter::convertAttr(__args) {
     } else {
         AttrValue::TextValue tv{};
         tv.value += get_text(one(a, N::Value));
-        print(fmt("Attribute is text value {}", tv));
+        print(hstd::fmt("Attribute is text value {}", tv));
         result.data = tv;
     }
 
@@ -2189,7 +2194,7 @@ sem::AttrValue OrgConverter::convertAttr(__args) {
                 dim.first  = split.at(0).toInt();
                 if (split.has(1)) { dim.last = split.at(1).toInt(); }
             }
-            print(fmt("Attribute dimension span {}", dim));
+            print(hstd::fmt("Attribute dimension span {}", dim));
             result.span.push_back(dim);
         }
     }
@@ -2421,7 +2426,7 @@ SemId<ErrorItem> OrgConverter::SemErrorItem(
     char const*                     function) {
     auto res  = Sem<ErrorItem>(adapter);
     res->diag = diag;
-    if (TraceState) { print(fmt("{}", diag), line, function); }
+    if (TraceState) { print(hstd::fmt("{}", diag), line, function); }
     return res;
 }
 
@@ -2510,7 +2515,7 @@ OrgConverter::ConvResult<BlockCode> OrgConverter::convertBlockCode(__args) {
                 && conv->at(0)->is(osk::Link)) {
                 conv = conv.at(0);
             }
-            print(fmt("Parsed result body as {}", conv->getKind()));
+            print(hstd::fmt("Parsed result body as {}", conv->getKind()));
             auto result_block  = Sem<sem::BlockCodeEvalResult>(res);
             result_block->node = conv;
             result->result.push_back(result_block);
@@ -2547,11 +2552,11 @@ Vec<OrgConverter::ConvResult<Org>> OrgConverter::flatConvertAttached(
         auto it  = items.at(i);
         auto res = convert(it);
         if (res->dyn_cast<sem::Attached>()) {
-            print(fmt("{} is attached", res->getKind()));
+            print(hstd::fmt("{} is attached", res->getKind()));
             buffer.push_back(res);
         } else {
             if (auto res_stmt = res.asOpt<sem::Stmt>()) {
-                print(fmt("{} is a statement, adding attached", res->getKind()));
+                print(hstd::fmt("{} is a statement, adding attached", res->getKind()));
                 if (auto par = res_stmt.asOpt<sem::Paragraph>();
                     par && par->subnodes.size() == 1) {
                     if (auto link = par->subnodes.at(0).asOpt<sem::Link>()) {
@@ -2569,14 +2574,19 @@ Vec<OrgConverter::ConvResult<Org>> OrgConverter::flatConvertAttached(
                 Opt<CRw<org::parse::OrgAdapter>> next_opt = items.get(i + offset + 1);
                 while (next_opt) {
                     if (next_opt->get().getKind() == onk::CmdTblfm) {
-                        print(fmt(
-                            "tblfm attached {} + {} {}", i, offset, next_opt->get().id));
+                        print(
+                            hstd::fmt(
+                                "tblfm attached {} + {} {}",
+                                i,
+                                offset,
+                                next_opt->get().id));
                         auto tblfm = convertCmdTblfm(next_opt->get());
                         res_stmt->attached.push_back(tblfm.unwrap());
                         ++offset;
                     } else {
                         print(
-                            fmt("next node is not post-attached {}",
+                            hstd::fmt(
+                                "next node is not post-attached {}",
                                 next_opt->get().getKind()));
                         break;
                     }
@@ -2587,7 +2597,9 @@ Vec<OrgConverter::ConvResult<Org>> OrgConverter::flatConvertAttached(
                 i += offset;
 
             } else {
-                print(fmt("{} is not a statement, releasing attached", res->getKind()));
+                print(
+                    hstd::fmt(
+                        "{} is not a statement, releasing attached", res->getKind()));
                 for (auto const& buf : buffer) { result.push_back(buf); }
             }
             buffer.clear();
@@ -2704,7 +2716,8 @@ SemId<Org> OrgConverter::convert(__args) {
         case onk::CriticMarkStructure: return convertCriticMarkup(a).unwrap();
         case onk::BlockDynamicFallback: return convertBlockDynamicFallback(a).unwrap();
         default: {
-            return SemError(a, MakeInternal(fmt("ERR Unknown content {}", a.getKind())));
+            return SemError(
+                a, MakeInternal(hstd::fmt("ERR Unknown content {}", a.getKind())));
         }
     }
 #undef CASE
@@ -2850,7 +2863,8 @@ void OrgConverter::convertDocumentOptions(
                     MakeConvert(
                         a,
                         ErrorTable::UnexpectedDocumentOption,
-                        fmt("Value {}, "
+                        hstd::fmt(
+                            "Value {}, "
                             "head:'{}', "
                             "tail:'{}'",
                             value,
@@ -2864,7 +2878,9 @@ void OrgConverter::convertDocumentOptions(
             opts->push_back(SemError(
                 a,
                 MakeConvert(
-                    a, ErrorTable::UnexpectedDocumentOption, fmt("value {}", value))));
+                    a,
+                    ErrorTable::UnexpectedDocumentOption,
+                    hstd::fmt("value {}", value))));
         }
     }
 }

--- a/src/haxorg/sem/SemConvert.cpp
+++ b/src/haxorg/sem/SemConvert.cpp
@@ -28,6 +28,7 @@
 #include <hstd/stdlib/OptFormatter.hpp>
 #include <haxorg/parse/OrgTypesFormatter.hpp>
 #include <haxorg/sem/SemOrgTypesFormatter.hpp>
+#include <hstd/stdlib/MapFormatter.hpp>
 
 
 namespace {

--- a/src/haxorg/sem/SemConvertUtils.cpp
+++ b/src/haxorg/sem/SemConvertUtils.cpp
@@ -149,7 +149,7 @@ void OrgConverter::report(OrgConverter::Report const& in) {
 
         switch (in.kind) {
             case ReportKind::EnterField: {
-                os << "{ " << fmt1(in.field.value()) << fmt(" @{}", in.line) << " "
+                os << "{ " << fmt1(in.field.value()) << hstd::fmt(" @{}", in.line) << " "
                    << getLoc();
                 if (in.msg) { os << " " << *in.msg; }
                 break;
@@ -165,7 +165,8 @@ void OrgConverter::report(OrgConverter::Report const& in) {
             }
 
             case ReportKind::Enter: {
-                os << "> " << (in.function ? in.function : "") << fmt(" @{}", in.line);
+                os << "> " << (in.function ? in.function : "")
+                   << hstd::fmt(" @{}", in.line);
                 if (in.node.has_value() && in.node->isValid()) {
                     os << " " << fmt1(in.node->kind())
                        << " ID:" << fmt1(in.node->id.getUnmasked());
@@ -185,7 +186,8 @@ void OrgConverter::report(OrgConverter::Report const& in) {
             }
 
             case ReportKind::Print: {
-                os << "  " << (in.function ? in.function : "") << fmt(" @{}", in.line);
+                os << "  " << (in.function ? in.function : "")
+                   << hstd::fmt(" @{}", in.line);
                 if (in.msg) {
                     os << " ";
                     int prefix_end = os.position;

--- a/src/haxorg/sem/SemOrgBase.hpp
+++ b/src/haxorg/sem/SemOrgBase.hpp
@@ -11,7 +11,6 @@
 #include <hstd/stdlib/Opt.hpp>
 
 #include <haxorg/parse/OrgTypes.hpp>
-#include <format>
 #include <hstd/system/reflection.hpp>
 
 

--- a/src/haxorg/sem/SemOrgBaseSharedTypes.hpp
+++ b/src/haxorg/sem/SemOrgBaseSharedTypes.hpp
@@ -64,34 +64,32 @@ std::string format_enum_value(OrgNodeKind kind);
 // 800-900ms and are instantiated in about 20 translation units.
 
 
-// clang-format off
-
 namespace hstd {
-using back_inserter_string_format_context = std::basic_format_context<std::back_insert_iterator<std::basic_string<char>>, char>;
+using back_inserter_string_format_context = std::
+    basic_format_context<std::back_insert_iterator<std::basic_string<char>>, char>;
 }
 
 
 template <>
-struct std::formatter<OrgTokenKind> : std::formatter<std::string> {
-    template <class FormatContext>
-    auto format(OrgTokenKind const& value, FormatContext& ctx) const -> typename FormatContext::iterator {
+struct fmt::formatter<OrgTokenKind> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+    auto           format(OrgTokenKind const& value, fmt::format_context& ctx) const {
         return ::hstd::fmt_ctx(org::sem::detail::format_enum_value(value), ctx);
     }
 };
 
 template <>
-struct std::formatter<OrgSemKind> : std::formatter<std::string> {
-    template <class FormatContext>
-    auto format(OrgSemKind const& value, FormatContext& ctx) const -> typename FormatContext::iterator {
+struct fmt::formatter<OrgSemKind> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+    auto           format(OrgSemKind const& value, fmt::format_context& ctx) const {
         return ::hstd::fmt_ctx(org::sem::detail::format_enum_value(value), ctx);
     }
 };
 
 template <>
-struct std::formatter<OrgNodeKind> : std::formatter<std::string> {
-    template <class FormatContext>
-    auto format(OrgNodeKind const& value, FormatContext& ctx) const -> typename FormatContext::iterator {
+struct fmt::formatter<OrgNodeKind> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+    auto           format(OrgNodeKind const& value, fmt::format_context& ctx) const {
         return ::hstd::fmt_ctx(org::sem::detail::format_enum_value(value), ctx);
     }
 };
-// clang-format on

--- a/src/haxorg/sem/SemOrgFormat.cpp
+++ b/src/haxorg/sem/SemOrgFormat.cpp
@@ -25,7 +25,7 @@ std::string FormatTimeDelta(long delta_seconds) {
     long delta   = delta_seconds / 60;
     long hours   = delta / 60;
     long minutes = delta % 60;
-    return std::format("{}:{:02}", hours, minutes);
+    return fmt::format("{}:{:02}", hours, minutes);
 }
 
 std::string FormatPath(org::sem::SubtreePath const& path) { return join("/", path.path); }
@@ -210,7 +210,9 @@ auto Formatter::toString(SemId<Document> id, Context const& ctx) -> Res {
 
             if (col.property) { res += col.property.value(); }
 
-            if (col.propertyTitle) { res += fmt("({})", col.propertyTitle.value()); }
+            if (col.propertyTitle) {
+                res += hstd::fmt("({})", col.propertyTitle.value());
+            }
             using type = sem::ColumnView::Summary;
 
             if (col.summary) {
@@ -346,27 +348,28 @@ auto Formatter::toString(SemId<Document> id, Context const& ctx) -> Res {
                 }
                 case P::Kind::ExportLatexHeader: {
                     add(result,
-                        str(fmt(
+                        str(hstd::fmt(
                             "#+latex_header: {}", prop.getExportLatexHeader().header)));
                     break;
                 }
                 case P::Kind::ExportLatexClass: {
                     add(result,
-                        str(
-                            fmt("#+latex_header: {}",
-                                prop.getExportLatexClass().latexClass)));
+                        str(hstd::fmt(
+                            "#+latex_header: {}",
+                            prop.getExportLatexClass().latexClass)));
                     break;
                 }
                 case P::Kind::ExportLatexClassOptions: {
                     add(result,
-                        str(
-                            fmt("#+latex_class_options: {}",
-                                prop.getExportLatexClassOptions().options.at(0))));
+                        str(hstd::fmt(
+                            "#+latex_class_options: {}",
+                            prop.getExportLatexClassOptions().options.at(0))));
                     break;
                 }
                 default: {
                     throw std::logic_error(
-                        fmt("Unexpected document-level property: {}", prop.getKind()));
+                        hstd::fmt(
+                            "Unexpected document-level property: {}", prop.getKind()));
                 }
             }
         }
@@ -429,7 +432,7 @@ auto Formatter::toString(SemId<InlineFootnote> id, Context const& ctx) -> Res {
             str("]"),
         });
     } else {
-        return str(fmt("[fn:{}]", id->tag));
+        return str(hstd::fmt("[fn:{}]", id->tag));
     }
 }
 
@@ -449,7 +452,7 @@ Formatter::Res Formatter::toString(sem::LispCode const& id, Context const& ctx) 
             },
             [&](C::KeyValue const& kv) {
                 return b.line({
-                    str(fmt(":{} ", kv.name)),
+                    str(hstd::fmt(":{} ", kv.name)),
                     toString(kv.value.front(), ctx),
                 });
             },
@@ -465,7 +468,7 @@ Formatter::Res Formatter::toString(sem::LispCode const& id, Context const& ctx) 
             [&](C::Ident const& i) -> Res { return str(i.name); },
             [&](C::Real const& r) -> Res { return str(fmt1(r.value)); },
             [&](C::Number const& r) -> Res { return str(fmt1(r.value)); },
-            [&](C::Text const& r) -> Res { return str(fmt("\"{}\"", r.value)); },
+            [&](C::Text const& r) -> Res { return str(hstd::fmt("\"{}\"", r.value)); },
         },
         id.data);
 }
@@ -786,17 +789,17 @@ auto Formatter::toString(SemId<CmdCall> id, Context const& ctx) -> Res {
 
 auto Formatter::toString(SemId<CmdCustomRaw> id, Context const& ctx) -> Res {
     if (id.isNil()) { return str("<nil>"); }
-    return b.line({str(fmt("#+{}: {}", id->name, id->text))});
+    return b.line({str(hstd::fmt("#+{}: {}", id->name, id->text))});
 }
 
 auto Formatter::toString(SemId<CmdCustomArgs> id, Context const& ctx) -> Res {
     if (id.isNil()) { return str("<nil>"); }
-    return b.line({str(fmt("#+{}:", id->name)), toString(id->attrs, ctx)});
+    return b.line({str(hstd::fmt("#+{}:", id->name)), toString(id->attrs, ctx)});
 }
 
 auto Formatter::toString(SemId<CmdCustomText> id, Context const& ctx) -> Res {
     if (id.isNil()) { return str("<nil>"); }
-    return b.line({str(fmt("#+{}: ", id->name)), toString(id->text, ctx)});
+    return b.line({str(hstd::fmt("#+{}: ", id->name)), toString(id->text, ctx)});
 }
 
 auto Formatter::toString(SemId<CmdName> id, Context const& ctx) -> Res {
@@ -843,7 +846,7 @@ auto Formatter::toString(SemId<Call> id, Context const& ctx) -> Res {
 
     for (auto const& it : id->attrs.positional.items) {
         if (it.getString().contains(",")) {
-            parameters.push_back(str(fmt("={}=", it.getString())));
+            parameters.push_back(str(hstd::fmt("={}=", it.getString())));
         } else {
             parameters.push_back(str(it.getString()));
         }
@@ -851,7 +854,8 @@ auto Formatter::toString(SemId<Call> id, Context const& ctx) -> Res {
 
     for (auto const& key : sorted(id->attrs.named.keys())) {
         for (auto const& it : id->attrs.named.at(key).items) {
-            parameters.push_back(str(fmt("{}={}", it.name.value(), it.getString())));
+            parameters.push_back(
+                str(hstd::fmt("{}={}", it.name.value(), it.getString())));
         }
     }
 
@@ -975,9 +979,9 @@ auto Formatter::toString(SemId<Cell> id, Context const& ctx) -> Res {
 
 auto Formatter::toString(sem::SubtreeCompletion const& id, Context const& ctx) -> Res {
     if (id.isPercent) {
-        return str(fmt("[{}%]", id.done));
+        return str(hstd::fmt("[{}%]", id.done));
     } else {
-        return str(fmt("[{}/{}]", id.done, id.full));
+        return str(hstd::fmt("[{}/{}]", id.done, id.full));
     }
 }
 
@@ -1157,7 +1161,9 @@ auto Formatter::toString(SemId<Subtree> id, Context const& ctx) -> Res {
 
         if (id->todo) { lead.push_back(str(id->todo.value())); }
         if (id->isComment) { lead.push_back(str("COMMENT")); }
-        if (id->priority) { lead.push_back(str(fmt("[#{}]", id->priority.value()))); }
+        if (id->priority) {
+            lead.push_back(str(hstd::fmt("[#{}]", id->priority.value())));
+        }
         if (id->isArchived) { tags.push_back(str("ARCHIVE")); }
 
         if (!id->title->subnodes.empty()) { lead.push_back(toString(id->title, ctx)); }
@@ -1192,7 +1198,7 @@ auto Formatter::toString(SemId<Subtree> id, Context const& ctx) -> Res {
 
     if (!id->properties.empty() || id->treeId) {
         add(head, str(":PROPERTIES:"));
-        if (id->treeId) { add(head, str(fmt(":ID: {}", *id->treeId))); }
+        if (id->treeId) { add(head, str(hstd::fmt(":ID: {}", *id->treeId))); }
 
         for (auto const& prop : id->properties) {
             using P = sem::NamedProperty;
@@ -1200,131 +1206,133 @@ auto Formatter::toString(SemId<Subtree> id, Context const& ctx) -> Res {
                 case P::Kind::CustomSubtreeFlags: {
                     add(head,
                         b.line({
-                            str(fmt(":prop_args:{}:", prop.getCustomSubtreeFlags().name)),
+                            str(hstd::fmt(
+                                ":prop_args:{}:", prop.getCustomSubtreeFlags().name)),
                             toString(prop.getCustomSubtreeFlags().value, ctx),
                         }));
                     break;
                 }
                 case P::Kind::CustomSubtreeJson: {
                     add(head,
-                        str(
-                            fmt(":prop_json:{}: {}",
-                                prop.getCustomSubtreeJson().name,
-                                prop.getCustomSubtreeJson().value.dump(0))));
+                        str(hstd::fmt(
+                            ":prop_json:{}: {}",
+                            prop.getCustomSubtreeJson().name,
+                            prop.getCustomSubtreeJson().value.dump(0))));
                     break;
                 }
                 case P::Kind::ExportLatexCompiler: {
                     add(head,
-                        str(
-                            fmt(":latex_compiler: {}",
-                                prop.getExportLatexCompiler().compiler)));
+                        str(hstd::fmt(
+                            ":latex_compiler: {}",
+                            prop.getExportLatexCompiler().compiler)));
                     break;
                 }
                 case P::Kind::ExportOptions: {
                     add(head,
-                        str(
-                            fmt(":export_options:{}: {}",
-                                prop.getExportOptions().backend,
-                                prop.getExportOptions().values
-                                    | rv::transform([](Pair<Str, Str> const& pair) {
-                                          return fmt("{}:{}", pair.first, pair.second);
-                                      })
-                                    | rv::intersperse(" ") //
-                                    | rv::join             //
-                                    | rs::to<std::string>())));
+                        str(hstd::fmt(
+                            ":export_options:{}: {}",
+                            prop.getExportOptions().backend,
+                            prop.getExportOptions().values
+                                | rv::transform([](Pair<Str, Str> const& pair) {
+                                      return hstd::fmt("{}:{}", pair.first, pair.second);
+                                  })
+                                | rv::intersperse(" ") //
+                                | rv::join             //
+                                | rs::to<std::string>())));
                     break;
                 }
                 case P::Kind::ExportLatexClassOptions: {
                     add(head,
-                        str(
-                            fmt(":latex_class_options: {}",
-                                prop.getExportLatexClassOptions().options)));
+                        str(hstd::fmt(
+                            ":latex_class_options: {}",
+                            prop.getExportLatexClassOptions().options)));
                     break;
                 }
                 case P::Kind::CookieData: {
                     add(head,
-                        str(
-                            fmt(":cookie: {}{}",
-                                prop.getCookieData().source,
-                                prop.getCookieData().isRecursive ? " recursive" : "")));
+                        str(hstd::fmt(
+                            ":cookie: {}{}",
+                            prop.getCookieData().source,
+                            prop.getCookieData().isRecursive ? " recursive" : "")));
                     break;
                 }
                 case P::Kind::ExportLatexHeader: {
                     add(head,
-                        str(fmt(
+                        str(hstd::fmt(
                             ":latex_header: {}", prop.getExportLatexHeader().header)));
                     break;
                 }
                 case P::Kind::CustomId: {
-                    add(head, str(fmt(":custom_id: {}", prop.getCustomId().value)));
+                    add(head, str(hstd::fmt(":custom_id: {}", prop.getCustomId().value)));
                     break;
                 }
                 case P::Kind::ExportLatexClass: {
                     add(head,
-                        str(fmt(
+                        str(hstd::fmt(
                             ":latex_class: {}", prop.getExportLatexClass().latexClass)));
                     break;
                 }
                 case P::Kind::Trigger: {
-                    add(head, str(fmt(":trigger:")));
+                    add(head, str(hstd::fmt(":trigger:")));
                     break;
                 }
                 case P::Kind::ArchiveTodo: {
-                    add(head, str(fmt(":archive_todo: {}", prop.getArchiveTodo().todo)));
+                    add(head,
+                        str(hstd::fmt(":archive_todo: {}", prop.getArchiveTodo().todo)));
                     break;
                 }
                 case P::Kind::ArchiveTarget: {
                     add(head,
-                        str(
-                            fmt(":archive: {}::* {}",
-                                prop.getArchiveTarget().pattern,
-                                FormatPath(prop.getArchiveTarget().path))));
+                        str(hstd::fmt(
+                            ":archive: {}::* {}",
+                            prop.getArchiveTarget().pattern,
+                            FormatPath(prop.getArchiveTarget().path))));
                     break;
                 }
                 case P::Kind::ArchiveOlpath: {
                     add(head,
-                        str(
-                            fmt(":archive_olpath: {}",
-                                FormatPath(prop.getArchiveOlpath().path))));
+                        str(hstd::fmt(
+                            ":archive_olpath: {}",
+                            FormatPath(prop.getArchiveOlpath().path))));
                     break;
                 }
                 case P::Kind::ArchiveTime: {
                     add(head,
-                        str(
-                            fmt(":archive_time: [{}]",
-                                prop.getArchiveTime().time.format(
-                                    UserTime::Format::OrgFormat))));
+                        str(hstd::fmt(
+                            ":archive_time: [{}]",
+                            prop.getArchiveTime().time.format(
+                                UserTime::Format::OrgFormat))));
                     break;
                 }
                 case P::Kind::Ordered: {
                     add(head,
-                        str(fmt(
+                        str(hstd::fmt(
                             ":ordered: {}", prop.getOrdered().isOrdered ? "t" : "nil")));
                     break;
                 }
                 case P::Kind::Nonblocking: {
                     add(head,
-                        str(
-                            fmt(":nonblocking: {}",
-                                prop.getNonblocking().isBlocking ? "t" : "nil")));
+                        str(hstd::fmt(
+                            ":nonblocking: {}",
+                            prop.getNonblocking().isBlocking ? "t" : "nil")));
                     break;
                 }
                 case P::Kind::HashtagDef: {
                     add(head,
-                        str(
-                            fmt(":hashtag_def: {}",
-                                nestedHashtag(prop.getHashtagDef().hashtag))));
+                        str(hstd::fmt(
+                            ":hashtag_def: {}",
+                            nestedHashtag(prop.getHashtagDef().hashtag))));
                     break;
                 }
                 case P::Kind::CustomArgs: {
                     auto const& ca   = prop.getCustomArgs();
                     auto        line = b.line();
                     add(line,
-                        str(
-                            fmt(":{}:{}{} ",
-                                ca.name,
-                                ca.sub.value_or(""),
-                                ca.sub ? ":" : "")));
+                        str(hstd::fmt(
+                            ":{}:{}{} ",
+                            ca.name,
+                            ca.sub.value_or(""),
+                            ca.sub ? ":" : "")));
 
                     add(line, toString(ca.attrs, ctx));
                     add(head, line);
@@ -1332,22 +1340,23 @@ auto Formatter::toString(SemId<Subtree> id, Context const& ctx) -> Res {
                 }
                 case P::Kind::RadioId: {
                     add(head,
-                        str(fmt(":radio_id: {}", join(" ", prop.getRadioId().words))));
+                        str(hstd::fmt(
+                            ":radio_id: {}", join(" ", prop.getRadioId().words))));
                     break;
                 }
                 case P::Kind::Unnumbered: {
-                    add(head, str(fmt(":unnumbered:")));
+                    add(head, str(hstd::fmt(":unnumbered:")));
                     break;
                 }
                 case P::Kind::Blocker: {
-                    add(head, str(fmt(":blocker: {}", prop.getBlocker().blockers)));
+                    add(head, str(hstd::fmt(":blocker: {}", prop.getBlocker().blockers)));
                     break;
                 }
                 case P::Kind::ArchiveCategory: {
                     add(head,
-                        str(
-                            fmt(":archive_category: {}",
-                                prop.getArchiveCategory().category)));
+                        str(hstd::fmt(
+                            ":archive_category: {}",
+                            prop.getArchiveCategory().category)));
                     break;
                 }
                 case P::Kind::Created: {
@@ -1372,18 +1381,20 @@ auto Formatter::toString(SemId<Subtree> id, Context const& ctx) -> Res {
                     add(head,
                         b.line(
                             {str(":EFFORT: "),
-                             str(
-                                 fmt("{}:{}",
-                                     prop.getEffort().hours,
-                                     prop.getEffort().minutes))}));
+                             str(hstd::fmt(
+                                 "{}:{}",
+                                 prop.getEffort().hours,
+                                 prop.getEffort().minutes))}));
                     break;
                 }
                 case P::Kind::Visibility: {
-                    add(head, str(fmt(":visibility: {}", prop.getVisibility().level)));
+                    add(head,
+                        str(hstd::fmt(":visibility: {}", prop.getVisibility().level)));
                     break;
                 }
                 case P::Kind::ArchiveFile: {
-                    add(head, str(fmt(":archive_file: {}", prop.getArchiveFile().file)));
+                    add(head,
+                        str(hstd::fmt(":archive_file: {}", prop.getArchiveFile().file)));
                     break;
                 }
             }
@@ -1431,7 +1442,8 @@ auto Formatter::toString(SemId<Subtree> id, Context const& ctx) -> Res {
                     auto const& state = log->head.getState();
 
                     log_head = b.line({
-                        str(fmt("- State \"{}\" from \"{}\" ", state.to, state.from)),
+                        str(hstd::fmt(
+                            "- State \"{}\" from \"{}\" ", state.to, state.from)),
                         toString(state.on, ctx),
                     });
 
@@ -1457,10 +1469,10 @@ auto Formatter::toString(SemId<Subtree> id, Context const& ctx) -> Res {
                             toString(clock.from, ctx),
                             str("--"),
                             toString(clock.to.value(), ctx),
-                            str(
-                                fmt(" => {}",
-                                    FormatTimeDelta(
-                                        GetTimeDelta(clock.from, clock.to.value())))),
+                            str(hstd::fmt(
+                                " => {}",
+                                FormatTimeDelta(
+                                    GetTimeDelta(clock.from, clock.to.value())))),
                         });
                     } else {
                         log_head = b.line({
@@ -1633,11 +1645,11 @@ auto Formatter::toString(SemId<BlockExport> id, Context const& ctx) -> Res {
 }
 
 auto Formatter::toString(SemId<InlineExport> id, Context const& ctx) -> Res {
-    return str(fmt("@@{}:{}@@", id->exporter, id->content));
+    return str(hstd::fmt("@@{}:{}@@", id->exporter, id->content));
 }
 
 auto Formatter::toString(SemId<CmdExport> id, Context const& ctx) -> Res {
-    return str(fmt("#+export_{}: {}", id->exporter, id->content));
+    return str(hstd::fmt("#+export_{}: {}", id->exporter, id->content));
 }
 
 auto Formatter::toString(SemId<BlockExample> id, Context const& ctx) -> Res {

--- a/src/haxorg/sem/SemOrgFormat.cpp
+++ b/src/haxorg/sem/SemOrgFormat.cpp
@@ -5,6 +5,7 @@
 #include <hstd/stdlib/Formatter.hpp>
 #include <hstd/stdlib/VariantFormatter.hpp>
 #include <hstd/stdlib/OptFormatter.hpp>
+#include <hstd/stdlib/VecFormatter.hpp>
 
 using namespace org::sem;
 using namespace hstd;

--- a/src/haxorg/sem/SemOrgTypesFormatter.hpp
+++ b/src/haxorg/sem/SemOrgTypesFormatter.hpp
@@ -4,21 +4,20 @@
 #include <hstd/stdlib/Formatter.hpp>
 
 template <>
-struct std::formatter<org::sem::SemId<org::sem::Org>> : std::formatter<std::string> {
-    template <typename FormatContext>
-    FormatContext::iterator format(
+struct fmt::formatter<org::sem::SemId<org::sem::Org>> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(
         org::sem::SemId<org::sem::Org> const& p,
-        FormatContext&                        ctx) const {
+        fmt::format_context&                  ctx) const {
         return hstd::fmt_ctx(p->getKind(), ctx);
     }
 };
 
 
 template <typename T>
-struct std::formatter<org::sem::SemId<T>> : std::formatter<std::string> {
-    template <typename FormatContext>
-    FormatContext::iterator format(org::sem::SemId<T> const& p, FormatContext& ctx)
-        const {
+struct fmt::formatter<org::sem::SemId<T>> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(org::sem::SemId<T> const& p, fmt::format_context& ctx) const {
         if (p.isNil()) {
             return hstd::fmt_ctx("<nil>", ctx);
         } else {
@@ -28,9 +27,9 @@ struct std::formatter<org::sem::SemId<T>> : std::formatter<std::string> {
 };
 
 template <>
-struct std::formatter<org::sem::OrgJson> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(org::sem::OrgJson const& p, FormatContext& ctx) const {
+struct fmt::formatter<org::sem::OrgJson> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(org::sem::OrgJson const& p, fmt::format_context& ctx) const {
         return hstd::fmt_ctx(p.dump(0), ctx);
     }
 };

--- a/src/haxorg/sem/SemOrgTypesFormatter.hpp
+++ b/src/haxorg/sem/SemOrgTypesFormatter.hpp
@@ -4,8 +4,8 @@
 #include <hstd/stdlib/Formatter.hpp>
 
 template <>
-struct fmt::formatter<org::sem::SemId<org::sem::Org>> : fmt::formatter<std::string> {
-
+struct fmt::formatter<org::sem::SemId<org::sem::Org>> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(
         org::sem::SemId<org::sem::Org> const& p,
         fmt::format_context&                  ctx) const {
@@ -15,8 +15,8 @@ struct fmt::formatter<org::sem::SemId<org::sem::Org>> : fmt::formatter<std::stri
 
 
 template <typename T>
-struct fmt::formatter<org::sem::SemId<T>> : fmt::formatter<std::string> {
-
+struct fmt::formatter<org::sem::SemId<T>> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(org::sem::SemId<T> const& p, fmt::format_context& ctx) const {
         if (p.isNil()) {
             return hstd::fmt_ctx("<nil>", ctx);
@@ -27,8 +27,8 @@ struct fmt::formatter<org::sem::SemId<T>> : fmt::formatter<std::string> {
 };
 
 template <>
-struct fmt::formatter<org::sem::OrgJson> : fmt::formatter<std::string> {
-
+struct fmt::formatter<org::sem::OrgJson> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(org::sem::OrgJson const& p, fmt::format_context& ctx) const {
         return hstd::fmt_ctx(p.dump(0), ctx);
     }

--- a/src/haxorg/test/NodeTest.cpp
+++ b/src/haxorg/test/NodeTest.cpp
@@ -88,7 +88,7 @@ struct verbose_convert {
             if (!knownFieldCache.contains(name)) {
                 throw RepresentationException(
                     it.first.Mark(),
-                    std::format(
+                    fmt::format(
                         "Unexpected field name '{}', expected {}",
                         name,
                         join(" or ", knownFieldCache.keys())));

--- a/src/haxorg/test/corpusrunner.cpp
+++ b/src/haxorg/test/corpusrunner.cpp
@@ -443,7 +443,7 @@ CorpusRunner::RunResult::NodeCompare CorpusRunner::compareNodes(
 
                     auto group = line.isLhs ? &parsed : &expected;
 
-                    return fmt(
+                    return hstd::fmt(
                         "{} {} {}({})",
                         line.index().value(),
                         node.kind,
@@ -457,10 +457,11 @@ CorpusRunner::RunResult::NodeCompare CorpusRunner::compareNodes(
                                       hshow_opts().excl(hshow_flag::use_quotes))
                                       .toString(false))
                             : std::string(""),
-                        node.isTerminal() ? fmt("id={} kind={}",
+                        node.isTerminal() ? hstd::fmt(
+                                                "id={} kind={}",
                                                 node.getToken().getIndex(),
                                                 group->tokens->at(node.getToken()).kind)
-                                          : fmt("ext={}", node.getExtent()));
+                                          : hstd::fmt("ext={}", node.getExtent()));
                 }}};
 
         return {{.isOk = false, .failDescribe = text.format()}};
@@ -830,7 +831,7 @@ CorpusRunner::RunResult::LexCompare CorpusRunner::runSpecBaseLex(
 
     if (spec.debug.traceAll || spec.debug.printBaseLexed
         || spec.debug.printBaseLexedToFile) {
-        auto content = std::format("{}", yamlRepr(p.baseTokens));
+        auto content = fmt::format("{}", yamlRepr(p.baseTokens));
 
         if (spec.debug.traceAll || spec.debug.printBaseLexedToFile) {
             writeFile(spec, "base_lexed.yaml", content + "\n", relDebug);
@@ -885,7 +886,7 @@ CorpusRunner::RunResult::LexCompare CorpusRunner::runSpecLex(
     p.tokenizeConvert();
 
     if (spec.debug.traceAll || spec.debug.printLexed || spec.debug.printLexedToFile) {
-        auto content = std::format("{}", yamlRepr(p.tokens));
+        auto content = fmt::format("{}", yamlRepr(p.tokens));
 
         __perf_trace("cli", "write lexer yaml file");
         if (spec.debug.traceAll || spec.debug.printLexedToFile) {
@@ -960,7 +961,7 @@ CorpusRunner::RunResult::NodeCompare CorpusRunner::runSpecParse(
         writeFile(
             spec,
             "parsed_non_extended.yaml",
-            std::format("{}", yamlRepr(p.nodes)) + "\n",
+            fmt::format("{}", yamlRepr(p.nodes)) + "\n",
             relDebug);
     }
 
@@ -968,7 +969,7 @@ CorpusRunner::RunResult::NodeCompare CorpusRunner::runSpecParse(
 
     if (spec.debug.traceAll || spec.debug.printParsed || spec.debug.printParsedToFile) {
         writeFile(
-            spec, "parsed.yaml", std::format("{}", yamlRepr(p.nodes)) + "\n", relDebug);
+            spec, "parsed.yaml", fmt::format("{}", yamlRepr(p.nodes)) + "\n", relDebug);
 
         for (auto const& [colored, path] :
              Vec<Pair<bool, Str>>{{false, "parsed.txt"}, {true, "parsed_colored.ansi"}}) {
@@ -1026,7 +1027,7 @@ CorpusRunner::RunResult::SemCompare CorpusRunner::runSpecSem(
 
         writeFileOrStdout(
             spec.debugFile("sem.yaml", relDebug),
-            std::format("{}", toTestYaml(document)) + "\n",
+            fmt::format("{}", toTestYaml(document)) + "\n",
             spec.debug.traceAll || spec.debug.printSemToFile);
 
         {
@@ -1137,7 +1138,7 @@ TestResult org::test::gtest_run_spec(
 
     if (result.isOk() && result.isSkip()) {
         test.data = TestResult::Skip{
-            .msg = fmt(
+            .msg = hstd::fmt(
                 "Partially covered test: {}{}{}",
                 spec.debug.doLex ? "" : "lex is disabled ",
                 spec.debug.doParse ? "" : "parse is disabled ",
@@ -1179,7 +1180,7 @@ TestResult org::test::gtest_run_spec(
         runner.writeFile(spec, "failure.txt", os.toString(false), "fail");
 
         test.data = TestResult::Fail{
-            .msg = fmt(
+            .msg = hstd::fmt(
                 "{} failed, , wrote debug to  {}",
                 params.fullName(),
                 spec.debug.debugOutDir),
@@ -1191,8 +1192,8 @@ TestResult org::test::gtest_run_spec(
 
 std::string TestParams::testName() const {
     std::string final;
-    for (char const& ch :
-         fmt("{} at {}",
+    for (char const& ch : hstd::fmt(
+             "{} at {}",
              spec.name.has_value() ? spec.name.value() : std::string("<spec>"),
              file.stem())) {
         if (std::isalnum(ch) || ch == '_') {
@@ -1258,10 +1259,12 @@ hstd::Func<void(org::parse::OrgNodeGroup::TreeReprConf::WriteParams const&)> org
                         par.os << " ";
                     }
                     if (name) {
-                        par.os << par.os.magenta() << fmt("{}", *name) << par.os.end();
+                        par.os << par.os.magenta() << hstd::fmt("{}", *name)
+                               << par.os.end();
                     } else {
                         par.os << par.os.red()
-                               << fmt("!! Missing field name for "
+                               << hstd::fmt(
+                                      "!! Missing field name for "
                                       "element {} of node {} !!",
                                       *par.subnodeIdx,
                                       OrgAdapter(nodes, *par.parent).getKind())
@@ -1276,7 +1279,7 @@ hstd::Func<void(org::parse::OrgNodeGroup::TreeReprConf::WriteParams const&)> org
                 if (parseAddedOnLine != nullptr
                     && parseAddedOnLine->contains(par.current)) {
                     par.os << " " << par.os.red()
-                           << fmt(" @{}", parseAddedOnLine->at(par.current))
+                           << hstd::fmt(" @{}", parseAddedOnLine->at(par.current))
                            << par.os.end();
                 }
                 break;

--- a/src/haxorg/test/corpusrunner.cpp
+++ b/src/haxorg/test/corpusrunner.cpp
@@ -26,6 +26,7 @@
 #include <hstd/stdlib/VariantFormatter.hpp>
 #include <hstd/stdlib/OptFormatter.hpp>
 #include <haxorg/parse/OrgTypesFormatter.hpp>
+#include <hstd/stdlib/VecFormatter.hpp>
 
 using namespace org::test;
 using namespace hstd;

--- a/src/hstd/CMakeLists.txt
+++ b/src/hstd/CMakeLists.txt
@@ -27,7 +27,7 @@ glob_add_sources2(TARGET hstd LS_REGEX "${BASE}/src/hstd/system/.*" SEARCH_BASE 
 glob_add_sources2(TARGET hstd LS_REGEX "${BASE}/src/hstd/ext/.*" SEARCH_BASE "${BASE}")
 
 target_link_libraries(hstd PUBLIC yaml-cpp::yaml-cpp range-v3::range-v3
-                                  nlohmann_json::nlohmann_json cctz::cctz)
+                                  nlohmann_json::nlohmann_json cctz::cctz fmt::fmt)
 
 if(${ORG_DEPS_USE_PACKAGED_BOOST})
   target_link_libraries(hstd PUBLIC Boost::boost_describe Boost::boost_preprocessor)

--- a/src/hstd/ext/astdiff/astdiff.hpp
+++ b/src/hstd/ext/astdiff/astdiff.hpp
@@ -145,27 +145,30 @@ struct Node {
 } // namespace hstd::ext::diff
 
 template <>
-struct std::formatter<hstd::ext::diff::NodeIdx> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(hstd::ext::diff::NodeIdx const& p, FormatContext& ctx) const {
-        return fmt_ctx(p.Offset, ctx);
+struct fmt::formatter<hstd::ext::diff::NodeIdx> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+    hstd::fmt_iter format(hstd::ext::diff::NodeIdx const& p, fmt::format_context& ctx)
+        const {
+        return ::hstd::fmt_ctx(p.Offset, ctx);
     }
 };
 
 
 template <>
-struct std::formatter<hstd::ext::diff::NodeStore::Id> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(hstd::ext::diff::NodeStore::Id const& p, FormatContext& ctx) const {
+struct fmt::formatter<hstd::ext::diff::NodeStore::Id> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+    hstd::fmt_iter format(
+        hstd::ext::diff::NodeStore::Id const& p,
+        fmt::format_context&                  ctx) const {
         return ::hstd::fmt_ctx(p.id, ctx);
     }
 };
 
 template <>
-struct std::formatter<hstd::ext::diff::Node> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(hstd::ext::diff::Node const& p, FormatContext& ctx) {
-        return std::format(
+struct fmt::formatter<hstd::ext::diff::Node> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+    auto           format(hstd::ext::diff::Node const& p, fmt::format_context& ctx) {
+        return fmt::format(
             "<H: {}, D: {}, S: {}, P: {}, L: {}, R: {}>",
             p.Height,
             p.Depth,
@@ -802,5 +805,5 @@ void printMapping(
 } // namespace hstd::ext::diff
 
 template <>
-struct std::formatter<hstd::ext::diff::ASTDiff*>
+struct fmt::formatter<hstd::ext::diff::ASTDiff*>
     : hstd::std_format_ptr_as_hex<hstd::ext::diff::ASTDiff> {};

--- a/src/hstd/ext/bimap_wrap.hpp
+++ b/src/hstd/ext/bimap_wrap.hpp
@@ -258,25 +258,24 @@ class StableNto1Bimap
 } // namespace hstd::ext
 
 template <typename L, typename R, typename LHash, typename RHash>
-struct std::formatter<hstd::ext::Unordered1to1Bimap<L, R, LHash, RHash>>
-    : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(
+struct fmt::formatter<hstd::ext::Unordered1to1Bimap<L, R, LHash, RHash>> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+    auto           format(
         hstd::ext::Unordered1to1Bimap<L, R, LHash, RHash> const& p,
-        FormatContext&                                           ctx) const {
+        fmt::format_context&                                     ctx) const {
         bool first = true;
-        fmt_ctx("{", ctx);
+        hstd::fmt_ctx("{", ctx);
         for (auto const& [left, right] : p.get_map()) {
             if (first) {
                 first = false;
             } else {
-                fmt_ctx(", ", ctx);
+                hstd::fmt_ctx(", ", ctx);
             }
-            fmt_ctx(left, ctx);
-            fmt_ctx("<>", ctx);
-            fmt_ctx(right, ctx);
+            hstd::fmt_ctx(left, ctx);
+            hstd::fmt_ctx("<>", ctx);
+            hstd::fmt_ctx(right, ctx);
         }
 
-        return fmt_ctx("}", ctx);
+        return hstd::fmt_ctx("}", ctx);
     }
 };

--- a/src/hstd/ext/error_write.cpp
+++ b/src/hstd/ext/error_write.cpp
@@ -105,7 +105,7 @@ struct Writer {
         char const* function = __builtin_FUNCTION()) {
         if (config->debug_writes) {
             stream << stream.green() << value << stream.end() << stream.blue()
-                   << fmt("@{}", line) << stream.end();
+                   << hstd::fmt("@{}", line) << stream.end();
         } else {
             stream << value;
         }
@@ -161,7 +161,7 @@ struct MarginContext {
         bool       force_scope = false,
         int        line        = __builtin_LINE()) const {
         if (config.debug_scopes || force_scope) {
-            w.stream << fmt("«{}:{}«", line, function);
+            w.stream << hstd::fmt("«{}:{}«", line, function);
             return finally_std{[&]() { w.stream << "»»"; }};
         } else {
             return finally_std::nop();

--- a/src/hstd/ext/error_write.cpp
+++ b/src/hstd/ext/error_write.cpp
@@ -9,6 +9,7 @@
 #include <hstd/ext/logger.hpp>
 #include <boost/preprocessor/seq.hpp>
 #include <hstd/stdlib/OptFormatter.hpp>
+#include <hstd/stdlib/ColTextFormatter.hpp>
 
 using namespace hstd::ext;
 using namespace hstd;

--- a/src/hstd/ext/error_write.hpp
+++ b/src/hstd/ext/error_write.hpp
@@ -504,9 +504,9 @@ class [[refl(R"({"default-constructor": false})")]] Report {
 
 
 template <>
-struct std::formatter<hstd::ext::CodeSpan> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(hstd::ext::CodeSpan const& p, FormatContext& ctx) const {
+struct fmt::formatter<hstd::ext::CodeSpan> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(hstd::ext::CodeSpan const& p, fmt::format_context& ctx) const {
         return ::hstd::fmt_ctx(
             hstd::fmt("<{}:{}..{}>", p.source(), p.start(), p.end()), ctx);
     }
@@ -514,7 +514,7 @@ struct std::formatter<hstd::ext::CodeSpan> : std::formatter<std::string> {
 
 
 template <>
-struct std::formatter<hstd::ext::CodeSpan*>
+struct fmt::formatter<hstd::ext::CodeSpan*>
     : public hstd::std_format_ptr_as_value<hstd::ext::CodeSpan> {
     using std_format_ptr_as_value<hstd::ext::CodeSpan>::format;
 };

--- a/src/hstd/ext/error_write.hpp
+++ b/src/hstd/ext/error_write.hpp
@@ -504,8 +504,8 @@ class [[refl(R"({"default-constructor": false})")]] Report {
 
 
 template <>
-struct fmt::formatter<hstd::ext::CodeSpan> : fmt::formatter<std::string> {
-
+struct fmt::formatter<hstd::ext::CodeSpan> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(hstd::ext::CodeSpan const& p, fmt::format_context& ctx) const {
         return ::hstd::fmt_ctx(
             hstd::fmt("<{}:{}..{}>", p.source(), p.start(), p.end()), ctx);

--- a/src/hstd/ext/geometry/hstd_geometry.cpp
+++ b/src/hstd/ext/geometry/hstd_geometry.cpp
@@ -92,3 +92,36 @@ Point Path::currentPosition() const {
 
     return current;
 }
+
+fmt::format_context::iterator fmt::formatter<hstd::ext::geometry::Point>::format(
+    hstd::ext::geometry::Point const& p,
+    fmt::format_context&              ctx) const {
+    return hstd::fmt_ctx(
+        hstd::fmt(
+            "Point({}, {})", hstd::format_number(p.x()), hstd::format_number(p.y())),
+        ctx);
+}
+fmt::format_context::iterator fmt::formatter<hstd::ext::geometry::Size>::format(
+    hstd::ext::geometry::Size const& p,
+    fmt::format_context&             ctx) const {
+    return hstd::fmt_ctx(
+        hstd::fmt("Size(width={}, height={})", p.width(), p.height()), ctx);
+}
+
+fmt::context::iterator fmt::formatter<hstd::ext::geometry::Rect>::format(
+    hstd::ext::geometry::Rect const& b,
+    format_context&                  ctx) const {
+    return hstd::fmt_ctx(
+        hstd::fmt(
+            "Rect({}, {}, {})",
+            b.min_corner(),
+            hstd::format_number(b.width()),
+            hstd::format_number(b.height())),
+        ctx);
+}
+
+hstd::fmt_iter fmt::formatter<hstd::ext::geometry::Path>::format(
+    hstd::ext::geometry::Path const& p,
+    fmt::format_context&             ctx) const {
+    return hstd::fmt_ctx(hstd::fmt("Path(commands={})", p.commands), ctx);
+}

--- a/src/hstd/ext/geometry/hstd_geometry.cpp
+++ b/src/hstd/ext/geometry/hstd_geometry.cpp
@@ -1,4 +1,6 @@
 #include "hstd_geometry.hpp"
+#include <hstd/stdlib/Formatter.hpp>
+#include <hstd/stdlib/VecFormatter.hpp>
 
 using namespace hstd::ext::geometry;
 
@@ -124,4 +126,11 @@ hstd::fmt_iter fmt::formatter<hstd::ext::geometry::Path>::format(
     hstd::ext::geometry::Path const& p,
     fmt::format_context&             ctx) const {
     return hstd::fmt_ctx(hstd::fmt("Path(commands={})", p.commands), ctx);
+}
+
+hstd::fmt_iter fmt::formatter<hstd::ext::geometry::Polygon>::format(
+    hstd::ext::geometry::Polygon const& b,
+    format_context&                     ctx) const {
+    return hstd::fmt_ctx(
+        hstd::fmt("Polygon(points={})", hstd::Vec<Point>{b.begin(), b.end()}), ctx);
 }

--- a/src/hstd/ext/geometry/hstd_geometry.hpp
+++ b/src/hstd/ext/geometry/hstd_geometry.hpp
@@ -647,6 +647,12 @@ struct fmt::formatter<hstd::ext::geometry::Rect> {
         const;
 };
 
+template <>
+struct fmt::formatter<hstd::ext::geometry::Polygon> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+    hstd::fmt_iter format(hstd::ext::geometry::Polygon const& b, fmt::format_context& ctx)
+        const;
+};
 
 namespace hstd {
 template <>

--- a/src/hstd/ext/geometry/hstd_geometry.hpp
+++ b/src/hstd/ext/geometry/hstd_geometry.hpp
@@ -618,47 +618,33 @@ struct Path {
 } // namespace hstd::ext::geometry
 
 template <>
-struct std::formatter<hstd::ext::geometry::Path> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(hstd::ext::geometry::Path const& p, FormatContext& ctx) const {
-        return hstd::fmt_ctx(hstd::fmt("Path(commands={})", p.commands), ctx);
-    }
+struct fmt::formatter<hstd::ext::geometry::Path> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+    hstd::fmt_iter format(hstd::ext::geometry::Path const& p, fmt::format_context& ctx)
+        const;
 };
 
 
 template <>
-struct std::formatter<hstd::ext::geometry::Point> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(hstd::ext::geometry::Point const& p, FormatContext& ctx) const {
-        return hstd::fmt_ctx(
-            hstd::fmt(
-                "Point({}, {})", hstd::format_number(p.x()), hstd::format_number(p.y())),
-            ctx);
-    }
+struct fmt::formatter<hstd::ext::geometry::Point> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+    hstd::fmt_iter format(hstd::ext::geometry::Point const& p, fmt::format_context& ctx)
+        const;
 };
 
 template <>
-struct std::formatter<hstd::ext::geometry::Size> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(hstd::ext::geometry::Size const& p, FormatContext& ctx) const {
-        return hstd::fmt_ctx(
-            hstd::fmt("Size(width={}, height={})", p.width(), p.height()), ctx);
-    }
+struct fmt::formatter<hstd::ext::geometry::Size> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+    hstd::fmt_iter format(hstd::ext::geometry::Size const& p, fmt::format_context& ctx)
+        const;
 };
 
 
 template <>
-struct std::formatter<hstd::ext::geometry::Rect> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(hstd::ext::geometry::Rect const& b, FormatContext& ctx) const {
-        return hstd::fmt_ctx(
-            hstd::fmt(
-                "Rect({}, {}, {})",
-                b.min_corner(),
-                hstd::format_number(b.width()),
-                hstd::format_number(b.height())),
-            ctx);
-    }
+struct fmt::formatter<hstd::ext::geometry::Rect> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+    hstd::fmt_iter format(hstd::ext::geometry::Rect const& b, fmt::format_context& ctx)
+        const;
 };
 
 

--- a/src/hstd/ext/geometry/hstd_visual.cpp
+++ b/src/hstd/ext/geometry/hstd_visual.cpp
@@ -5,6 +5,7 @@
 #include <hstd/stdlib/VariantFormatter.hpp>
 #include <hstd/stdlib/OptFormatter.hpp>
 #include <hstd/stdlib/algorithms.hpp>
+#include <hstd/stdlib/Formatter.hpp>
 
 namespace hstd::ext::visual {
 

--- a/src/hstd/ext/geometry/kiwi_ir.cpp
+++ b/src/hstd/ext/geometry/kiwi_ir.cpp
@@ -5,7 +5,6 @@
 
 #    include <algorithm>
 #    include <filesystem>
-#    include <format>
 #    include <sstream>
 #    include <stdexcept>
 
@@ -191,10 +190,10 @@ Rect::Rect(
     , y0(y0)
     , width0(width0)
     , height0(height0)
-    , x(std::format("{}.x", this->rect_id))
-    , y(std::format("{}.y", this->rect_id))
-    , width(std::format("{}.width", this->rect_id))
-    , height(std::format("{}.height", this->rect_id)) {}
+    , x(fmt::format("{}.x", this->rect_id))
+    , y(fmt::format("{}.y", this->rect_id))
+    , width(fmt::format("{}.width", this->rect_id))
+    , height(fmt::format("{}.height", this->rect_id)) {}
 
 Expr Rect::expr(RectAttr name) const {
     switch (name) {
@@ -272,7 +271,7 @@ Vec<EdgeDesc> AlignConstraint::describe_edges() const {
         edges.push_back(
             EdgeDesc{
                 item.rect_id,
-                std::format("align:{}", item.spec.anchor),
+                fmt::format("align:{}", item.spec.anchor),
                 anchor_axis(item.spec.anchor)});
     }
     return edges;
@@ -283,7 +282,7 @@ Str AlignConstraint::getRepr(hstd::Opt<RectMap> const& rects) const {
     joined.push_back(hstd::fmt("AlignConstraint strength={}", strength));
     for (auto const& item : items) {
         joined.push_back(
-            std::format(
+            fmt::format(
                 "  {} {} ({:+g})", item.rect_id, item.spec.anchor, item.spec.offset));
     }
 
@@ -310,19 +309,19 @@ Vec<EdgeDesc> SeparateConstraint::describe_edges() const {
     return {
         EdgeDesc{
             rect_b.rect_id,
-            std::format("separate:{}->{}+{}", rect_b.anchor, rect_b.anchor, offset),
+            fmt::format("separate:{}->{}+{}", rect_b.anchor, rect_b.anchor, offset),
             anchor_axis(rect_b.anchor),
         },
         EdgeDesc{
             rect_a.rect_id,
-            std::format("separate:{}->{}+{}", rect_b.anchor, rect_a.anchor, offset),
+            fmt::format("separate:{}->{}+{}", rect_b.anchor, rect_a.anchor, offset),
             anchor_axis(rect_a.anchor),
         },
     };
 }
 
 Str SeparateConstraint::getRepr(hstd::Opt<RectMap> const& rects) const {
-    return std::format(
+    return fmt::format(
         "SeparateConstraint({}.{} == {}.{} + {:g}, strength={})",
         rect_a.rect_id,
         rect_a.anchor,
@@ -419,7 +418,7 @@ Vec<EdgeDesc> MultiSeparateConstraint::describe_edges() const {
             edges.push_back(
                 EdgeDesc{
                     rect.rect_id,
-                    std::format("multi-separate:{}+{:g}", rect.anchor, step),
+                    fmt::format("multi-separate:{}+{:g}", rect.anchor, step),
                     anchor_axis(rect.anchor)});
         }
     }
@@ -439,7 +438,7 @@ Str MultiSeparateConstraint::getRepr(hstd::Opt<RectMap> const& rects) const {
 
     Vec<Str> joined;
     joined.push_back(
-        std::format("MultiSeparateConstraint(step={:g} strength={})", step, strength));
+        fmt::format("MultiSeparateConstraint(step={:g} strength={})", step, strength));
 
     auto     t_1   = Str{hstd::format_table(g_fmt, " => ", "")};
     auto     ind   = hstd::indent(t_1, 2);
@@ -541,7 +540,7 @@ Str ParentWrapConstraint::getRepr(hstd::Opt<RectMap> const& rects) const {
         if (i + 1 < nested_rect_ids.size()) { nested << ", "; }
     }
     nested << "]";
-    return std::format(
+    return fmt::format(
         "ParentWrapConstraint(parent={}, nested={}, padding={}, "
         "strength={})",
         parent_rect_id,
@@ -652,13 +651,13 @@ Str RelativeConstraint::getRepr(hstd::Opt<RectMap> const& rects) const {
 
     return hstd::join("\n", joined);
 
-    // Str wf = x_factor.has_value() ? std::format("{:g}",
+    // Str wf = x_factor.has_value() ? fmt::format("{:g}",
     // x_factor.value())
     //                               : "None";
-    // Str hf = y_factor.has_value() ? std::format("{:g}",
+    // Str hf = y_factor.has_value() ? fmt::format("{:g}",
     // y_factor.value())
     //                               : "None";
-    // return std::format(
+    // return fmt::format(
     //     "nestedRelativeToParentConstraint(nested={}, parent={}, "
     //     "width_factor={}, height_factor={}, x={}->{}{:+g},
     //     y={}->{}{:+g}, " "strength={})", relative_rect_id,
@@ -680,7 +679,7 @@ EvenGapConstraint::EvenGapConstraint(Vec<RectSpec2Side> rects_spec, Strength str
     for (auto const& spec : this->rects_spec) {
         if (anchor_axis(spec.min_anchor) != anchor_axis(spec.max_anchor)) {
             throw hstd::invalid_argument::init(
-                std::format(
+                fmt::format(
                     "EvenGapConstraint: min/max anchors of '{}' are on "
                     "different axes "
                     "({} vs {})",
@@ -695,7 +694,7 @@ EvenGapConstraint::EvenGapConstraint(Vec<RectSpec2Side> rects_spec, Strength str
         for (auto const& spec : this->rects_spec) {
             if (anchor_axis(spec.min_anchor) != common_axis) {
                 throw hstd::invalid_argument::init(
-                    std::format(
+                    fmt::format(
                         "EvenGapConstraint: mixed axes are not allowed, "
                         "'{}' has axis {} "
                         "while expected {}",
@@ -735,7 +734,7 @@ Vec<EdgeDesc> EvenGapConstraint::describe_edges() const {
         result.push_back(
             EdgeDesc{
                 g.rect_id,
-                std::format("even-gap:{}->{}", g.max_anchor, g.min_anchor),
+                fmt::format("even-gap:{}->{}", g.max_anchor, g.min_anchor),
                 anchor_axis(g.max_anchor)});
     }
     return result;
@@ -744,12 +743,12 @@ Vec<EdgeDesc> EvenGapConstraint::describe_edges() const {
 Str EvenGapConstraint::getRepr(hstd::Opt<RectMap> const& rects) const {
     Vec<Str> joined;
 
-    joined.push_back(std::format("EvenGapConstraint(strength={})", strength));
+    joined.push_back(fmt::format("EvenGapConstraint(strength={})", strength));
 
     for (int i = 0; i < rects_spec.size(); ++i) {
         RectSpec2Side const& s = rects_spec[i];
         joined.push_back(
-            std::format(
+            fmt::format(
                 "  id={}, min={}, max={}", s.rect_id, s.min_anchor, s.max_anchor));
     }
 
@@ -800,7 +799,7 @@ Vec<EdgeDesc> EqualSizeConstraint::describe_edges() const {
 }
 
 Str EqualSizeConstraint::getRepr(hstd::Opt<RectMap> const& rects) const {
-    return std::format(
+    return fmt::format(
         "EqualSizeConstraint(a={}, b={}, match_width={}, match_height={}, "
         "strength={})",
         rect_a_id,
@@ -839,7 +838,7 @@ Vec<EdgeDesc> LinearConstraint::describe_edges() const { return {}; }
 Str LinearConstraint::getRepr(hstd::Opt<RectMap> const& rects) const {
     Str rel = relation == Relation::EQ ? "==" : (relation == Relation::LE ? "<=" : ">=");
     Vec<Str> joined;
-    joined.push_back(std::format("LinearConstraint({} ..., strength={})", rel, strength));
+    joined.push_back(fmt::format("LinearConstraint({} ..., strength={})", rel, strength));
 
     joined.append(getBuildRepr(rects));
 
@@ -1071,7 +1070,7 @@ void Layout::to_graphviz(hstd::fs::path const& path) {
         for (auto const& [rect_id, rect] : rects) {
             auto node = //
                 (axis == Axis::X ? cluster_x : cluster_y)
-                    ->node(std::format("rect-{}-{}", rect_id, axis));
+                    ->node(fmt::format("rect-{}-{}", rect_id, axis));
 
             hstd::Vec<Str> rect_info;
             rect_info.push_back(hstd::fmt("{} {}", rect_id, axis));
@@ -1098,7 +1097,7 @@ void Layout::to_graphviz(hstd::fs::path const& path) {
 
     for (int idx = 0; idx < constraints.size(); ++idx) {
         auto const& constraint = constraints[idx];
-        Str         cid        = std::format("constraint-{}", idx);
+        Str         cid        = fmt::format("constraint-{}", idx);
         auto        cnode      = cluster_center->node(cid);
         cnode->setLabel(constraint->getRepr(rects));
         cnode->setNodeShape(graph::gv::NodeShape::rectangle);
@@ -1127,19 +1126,19 @@ Vec<ConstraintEntry> Layout::build_constraint_entries() const {
     for (auto const& [rect_id, rect] : rects) {
         entries.push_back(
             ConstraintEntry{
-                std::format("Rect({}).width >= 0", rect.rect_id),
+                fmt::format("Rect({}).width >= 0", rect.rect_id),
                 {(Expr(0) <= rect.expr(RectAttr::WIDTH)) | kiwi::strength::required},
             });
         entries.push_back(
             ConstraintEntry{
-                std::format("Rect({}).height >= 0", rect.rect_id),
+                fmt::format("Rect({}).height >= 0", rect.rect_id),
                 {(Expr(0) <= rect.expr(RectAttr::HEIGHT)) | kiwi::strength::required},
             });
 
         if (rect.x0.has_value()) {
             entries.push_back(
                 ConstraintEntry{
-                    std::format("Rect({}).x == {:g}", rect.rect_id, rect.x0.value()),
+                    fmt::format("Rect({}).x == {:g}", rect.rect_id, rect.x0.value()),
                     {(rect.expr(RectAttr::X) == rect.x0.value())
                      | kiwi::strength::required},
                 });
@@ -1147,7 +1146,7 @@ Vec<ConstraintEntry> Layout::build_constraint_entries() const {
         if (rect.y0.has_value()) {
             entries.push_back(
                 ConstraintEntry{
-                    std::format("Rect({}).y == {:g}", rect.rect_id, rect.y0.value()),
+                    fmt::format("Rect({}).y == {:g}", rect.rect_id, rect.y0.value()),
                     {(rect.expr(RectAttr::Y) == rect.y0.value())
                      | kiwi::strength::required},
                 });
@@ -1155,7 +1154,7 @@ Vec<ConstraintEntry> Layout::build_constraint_entries() const {
         if (rect.width0.has_value()) {
             entries.push_back(
                 ConstraintEntry{
-                    std::format(
+                    fmt::format(
                         "Rect({}).width == {:g}", rect.rect_id, rect.width0.value()),
                     {(rect.expr(RectAttr::WIDTH) == rect.width0.value())
                      | kiwi::strength::required},
@@ -1164,7 +1163,7 @@ Vec<ConstraintEntry> Layout::build_constraint_entries() const {
         if (rect.height0.has_value()) {
             entries.push_back(
                 ConstraintEntry{
-                    std::format(
+                    fmt::format(
                         "Rect({}).height == {:g}", rect.rect_id, rect.height0.value()),
                     {(rect.expr(RectAttr::HEIGHT) == rect.height0.value())
                      | kiwi::strength::required},
@@ -1304,7 +1303,7 @@ void Layout::verify_constraints() {
             // NOTE: primary candidate for tree-like data representation
             // optimization. [[f69705c4-9013-4919-a540-3c473bbadbaf]]
             os << "Unsatisfiable layout constraints detected.\n";
-            os << std::format(
+            os << fmt::format(
                 "Failing constraint: {}\n", describe_constraint_source(entry.source));
 
             auto describe_failure = [&](SatisfyFail const& fail) {
@@ -1341,7 +1340,7 @@ void Layout::verify_constraints() {
                     }
                 }
 
-                os << std::format(
+                os << fmt::format(
                     "    - first conflict detected when "
                     "adding lowered element {}\n",
                     flat_repr(fail.preceding.back().lowered.at(fail.failing)));
@@ -1356,7 +1355,7 @@ void Layout::verify_constraints() {
             } else {
                 os << "Conflicts with:\n";
                 for (auto const& src : conflicts.failures) {
-                    os << std::format(
+                    os << fmt::format(
                         "  - {}\n", describe_constraint_source(src.entry.source));
                     describe_failure(src.desc.value());
                 }

--- a/src/hstd/ext/geometry/kiwi_ir.hpp
+++ b/src/hstd/ext/geometry/kiwi_ir.hpp
@@ -22,16 +22,16 @@
 #    include <src/hstd/ext/geometry/kiwi_ir.pb.h>
 
 template <>
-struct fmt::formatter<kiwi::Variable> : fmt::formatter<std::string> {
-
+struct fmt::formatter<kiwi::Variable> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(kiwi::Variable const& p, fmt::format_context& ctx) const {
         return ::hstd::fmt_ctx(p.name(), ctx);
     }
 };
 
 template <>
-struct fmt::formatter<kiwi::Term> : fmt::formatter<std::string> {
-
+struct fmt::formatter<kiwi::Term> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(kiwi::Term const& p, fmt::format_context& ctx) const {
         return ::hstd::fmt_ctx(p.variable(), ctx);
     }

--- a/src/hstd/ext/geometry/kiwi_ir.hpp
+++ b/src/hstd/ext/geometry/kiwi_ir.hpp
@@ -22,17 +22,17 @@
 #    include <src/hstd/ext/geometry/kiwi_ir.pb.h>
 
 template <>
-struct std::formatter<kiwi::Variable> : std::formatter<std::string> {
-    template <typename FormatContext>
-    FormatContext::iterator format(kiwi::Variable const& p, FormatContext& ctx) const {
+struct fmt::formatter<kiwi::Variable> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(kiwi::Variable const& p, fmt::format_context& ctx) const {
         return ::hstd::fmt_ctx(p.name(), ctx);
     }
 };
 
 template <>
-struct std::formatter<kiwi::Term> : std::formatter<std::string> {
-    template <typename FormatContext>
-    FormatContext::iterator format(kiwi::Term const& p, FormatContext& ctx) const {
+struct fmt::formatter<kiwi::Term> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(kiwi::Term const& p, fmt::format_context& ctx) const {
         return ::hstd::fmt_ctx(p.variable(), ctx);
     }
 };

--- a/src/hstd/ext/geometry/kiwi_ir_repr.cpp
+++ b/src/hstd/ext/geometry/kiwi_ir_repr.cpp
@@ -19,7 +19,10 @@ void repr_impl(hstd::ColStream& os, kiwi::Expression const& e, int indent) {
         os.newline();
         os.indent(indent);
         os << hstd::fmt(
-            "{:<{}} {}", t.value().variable(), var_size, t.value().coefficient());
+            "{:<{}} {}",
+            hstd::fmt1(t.value().variable()),
+            var_size,
+            t.value().coefficient());
     }
 }
 
@@ -62,7 +65,10 @@ void repr_impl(hstd::ColStream& os, Expr::Node const& n, int indent) {
                 os.newline();
                 os.indent(indent + 1);
                 os << hstd::fmt(
-                    "{:<{}} {}", t.value().variable(), var_size, t.value().coefficient());
+                    "{:<{}} {}",
+                    hstd::fmt1(t.value().variable()),
+                    var_size,
+                    t.value().coefficient());
             }
 
             os.newline();

--- a/src/hstd/ext/graph/base/graph_attribute.hpp
+++ b/src/hstd/ext/graph/base/graph_attribute.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "graph_common.hpp"
+#include <hstd/stdlib/VecFormatter.hpp>
 
 namespace hstd::ext::graph {
 

--- a/src/hstd/ext/graph/base/graph_base.cpp
+++ b/src/hstd/ext/graph/base/graph_base.cpp
@@ -255,11 +255,10 @@ hstd::Opt<VertexID> IGraph::getParentVertex(
 }
 
 namespace {
-hstd::fmt_iter format_collection = hstd::rv::transform(
-                                       [](auto const& pair) -> std::string {
-                                           return pair.second->getStableID();
-                                       })
-                                 | hstd::rs::to<hstd::Vec>();
+auto format_collection //
+    = hstd::rv::transform(
+          [](auto const& pair) -> std::string { return pair.second->getStableID(); })
+    | hstd::rs::to<hstd::Vec>();
 } // namespace
 
 

--- a/src/hstd/ext/graph/base/graph_base.cpp
+++ b/src/hstd/ext/graph/base/graph_base.cpp
@@ -153,10 +153,10 @@ hstd::Vec<EdgeID> IGraph::trackSubVertexRelation(
     VertexID const&         parent,
     VertexID const&         sub) {
     if (!vertexIDs.contains(parent)) {
-        throw graph_error::init(std::format(vertex_not_found_msg, "parent ", parent));
+        throw graph_error::init(fmt::format(vertex_not_found_msg, "parent ", parent));
     }
     if (!vertexIDs.contains(sub)) {
-        throw graph_error::init(std::format(vertex_not_found_msg, "sub ", sub));
+        throw graph_error::init(fmt::format(vertex_not_found_msg, "sub ", sub));
     }
 
     hstd::Vec<EdgeID> result;
@@ -200,7 +200,7 @@ hstd::ext::graph::PortCollectionID hstd::ext::graph::IGraph::getPortCollectionID
 
 void hstd::ext::graph::IGraph::trackVertex(VertexID const& id) {
     if (vertexIDs.contains(id)) {
-        throw graph_error::init(std::format("Vertex {} already registered", id));
+        throw graph_error::init(fmt::format("Vertex {} already registered", id));
     }
     vertexIDs.insert(id);
     stableIdMap.insert_unqiue(getVertex(id)->getStableId(), id);
@@ -211,7 +211,7 @@ void hstd::ext::graph::IGraph::trackVertex(VertexID const& id) {
 hstd::UnorderedMap<EdgeCollectionID, IEdgeCollection::DependantDeletion> hstd::ext::
     graph::IGraph::untrackVertex(VertexID const& id) {
     if (!vertexIDs.contains(id)) {
-        throw graph_error::init(std::format(vertex_not_found_msg, "", id));
+        throw graph_error::init(fmt::format(vertex_not_found_msg, "", id));
     }
 
     hstd::UnorderedMap<EdgeCollectionID, IEdgeProvider::DependantDeletion> result;
@@ -255,10 +255,11 @@ hstd::Opt<VertexID> IGraph::getParentVertex(
 }
 
 namespace {
-auto format_collection = hstd::rv::transform([](auto const& pair) -> std::string {
-                             return pair.second->getStableID();
-                         })
-                       | hstd::rs::to<hstd::Vec>();
+hstd::fmt_iter format_collection = hstd::rv::transform(
+                                       [](auto const& pair) -> std::string {
+                                           return pair.second->getStableID();
+                                       })
+                                 | hstd::rs::to<hstd::Vec>();
 } // namespace
 
 

--- a/src/hstd/ext/graph/base/graph_common.hpp
+++ b/src/hstd/ext/graph/base/graph_common.hpp
@@ -305,15 +305,15 @@ class IGraphSerialReaderFactory : public hstd::OperationsTracer {
 } // namespace hstd::ext::graph
 
 template <>
-struct std::formatter<hstd::ext::graph::EdgeCollectionID>
+struct fmt::formatter<hstd::ext::graph::EdgeCollectionID>
     : public hstd::std_strong_typedef_formatter<hstd::ext::graph::EdgeCollectionID> {};
 
 template <>
-struct std::formatter<hstd::ext::graph::PortCollectionID>
+struct fmt::formatter<hstd::ext::graph::PortCollectionID>
     : public hstd::std_strong_typedef_formatter<hstd::ext::graph::PortCollectionID> {};
 
 template <>
-struct std::formatter<hstd::ext::graph::AttributeTrackerID>
+struct fmt::formatter<hstd::ext::graph::AttributeTrackerID>
     : public hstd::std_strong_typedef_formatter<hstd::ext::graph::AttributeTrackerID> {};
 
 

--- a/src/hstd/ext/graph/base/graph_hierarchy.cpp
+++ b/src/hstd/ext/graph/base/graph_hierarchy.cpp
@@ -14,7 +14,7 @@ using namespace hstd::ext::graph;
 IEdgeProvider::DependantDeletion IVertexHierarchy::untrackVertex(VertexID const& id) {
     DependantDeletion result;
     if (!vertexIDs.contains(id)) {
-        throw graph_error::init(std::format(vertex_not_found_msg, "", id));
+        throw graph_error::init(fmt::format(vertex_not_found_msg, "", id));
     }
 
     std::function<void(VertexID const&)> collect = [&](VertexID const& current) {
@@ -125,7 +125,7 @@ hstd::Vec<VertexID> IVertexHierarchy::getHierarchyCrossings(
 void IVertexHierarchy::trackVertex(VertexID const& id) {
     if (vertexIDs.contains(id)) {
         throw graph_error::init(
-            std::format(
+            fmt::format(
                 "Vertex {} already registered in hierarchy {}", id, getStableID()));
     }
     vertexIDs.insert(id);
@@ -138,11 +138,11 @@ void IVertexHierarchy::trackSubVertexRelation(
     VertexID const& sub) {
 
     if (!vertexIDs.contains(parent)) {
-        throw graph_error::init(std::format(vertex_not_found_msg, "parent ", parent));
+        throw graph_error::init(fmt::format(vertex_not_found_msg, "parent ", parent));
     }
 
     if (!vertexIDs.contains(sub)) {
-        throw graph_error::init(std::format(vertex_not_found_msg, "sub ", sub));
+        throw graph_error::init(fmt::format(vertex_not_found_msg, "sub ", sub));
     }
 
 
@@ -154,7 +154,7 @@ void IVertexHierarchy::trackSubVertexRelation(
         edge);
 
     if (parentMap.contains(sub)) {
-        throw graph_error::init(std::format("Vertex {} already has a parent", sub));
+        throw graph_error::init(fmt::format("Vertex {} already has a parent", sub));
     }
 
     parentMap.insert_or_assign(sub, parent);
@@ -172,10 +172,10 @@ EdgeID hstd::ext::graph::IVertexHierarchy::getNestingEdgeID(
     VertexID const& parent,
     VertexID const& sub) {
     if (!vertexIDs.contains(parent)) {
-        throw graph_error::init(std::format(vertex_not_found_msg, "Parent ", parent));
+        throw graph_error::init(fmt::format(vertex_not_found_msg, "Parent ", parent));
     }
     if (!vertexIDs.contains(sub)) {
-        throw graph_error::init(std::format(vertex_not_found_msg, "Sub ", sub));
+        throw graph_error::init(fmt::format(vertex_not_found_msg, "Sub ", sub));
     }
 
     return EdgeID::FromMasked(
@@ -187,14 +187,14 @@ void IVertexHierarchy::untrackSubVertexRelation(
     VertexID const& parent,
     VertexID const& sub) {
     if (!vertexIDs.contains(parent)) {
-        throw graph_error::init(std::format(vertex_not_found_msg, "Parent ", parent));
+        throw graph_error::init(fmt::format(vertex_not_found_msg, "Parent ", parent));
     }
     if (!vertexIDs.contains(sub)) {
-        throw graph_error::init(std::format(vertex_not_found_msg, "Sub ", sub));
+        throw graph_error::init(fmt::format(vertex_not_found_msg, "Sub ", sub));
     }
     if (!parentMap.contains(sub) || parentMap.at(sub) != parent) {
         throw graph_error::init(
-            std::format("Vertex {} is not a child of {}", sub, parent));
+            fmt::format("Vertex {} is not a child of {}", sub, parent));
     }
 
     parentMap.erase(sub);

--- a/src/hstd/ext/graph/jni_elk/src/elk_jni_wrapper.cpp
+++ b/src/hstd/ext/graph/jni_elk/src/elk_jni_wrapper.cpp
@@ -1,8 +1,7 @@
 #if ORG_BUILD_WITH_ELK
 #    include "elk_jni_wrapper.hpp"
 #    include <jni.h>
-#    include <iostream>
-#    include <format>
+#    include <fmt/format.h>
 
 
 #    include <dlfcn.h>
@@ -28,7 +27,7 @@ class ElkLayoutEngine::Impl {
         JavaVMOption   options[2];
 
         // Get the current directory and construct classpath
-        std::string classpath = std::format("-Djava.class.path={}", wrapper_jar);
+        std::string classpath = fmt::format("-Djava.class.path={}", wrapper_jar);
 
         options[0].optionString = const_cast<char*>(classpath.c_str());
         options[1].optionString = const_cast<char*>("-Xmx512m");
@@ -57,7 +56,7 @@ class ElkLayoutEngine::Impl {
                 case JNI_EINVAL: desc = "JNI_EINVAL (-6) /* invalid arguments */"; break;
             }
 
-            throw std::runtime_error(std::format("Failed to create JVM: {}", result));
+            throw std::runtime_error(fmt::format("Failed to create JVM: {}", result));
         }
 
         // Find the wrapper class

--- a/src/hstd/ext/graph/visual/adaptagrams_common.hpp
+++ b/src/hstd/ext/graph/visual/adaptagrams_common.hpp
@@ -61,8 +61,8 @@ inline void add_rect(visual::VisGroup& g, vpsc::Rectangle const& shape) {
 } // namespace hstd::ext::graph::adapt
 
 template <>
-struct fmt::formatter<vpsc::Rectangle> : fmt::formatter<std::string> {
-
+struct fmt::formatter<vpsc::Rectangle> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(vpsc::Rectangle const& rect, fmt::format_context& ctx) const {
         return ::hstd::fmt_ctx(
             hstd::fmt(

--- a/src/hstd/ext/graph/visual/adaptagrams_common.hpp
+++ b/src/hstd/ext/graph/visual/adaptagrams_common.hpp
@@ -61,10 +61,9 @@ inline void add_rect(visual::VisGroup& g, vpsc::Rectangle const& shape) {
 } // namespace hstd::ext::graph::adapt
 
 template <>
-struct std::formatter<vpsc::Rectangle> : std::formatter<std::string> {
-    template <typename FormatContext>
-    FormatContext::iterator format(vpsc::Rectangle const& rect, FormatContext& ctx)
-        const {
+struct fmt::formatter<vpsc::Rectangle> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(vpsc::Rectangle const& rect, fmt::format_context& ctx) const {
         return ::hstd::fmt_ctx(
             hstd::fmt(
                 "[{},{} + ({},{})]",

--- a/src/hstd/ext/graph/visual/graph_base_full_layout.cpp
+++ b/src/hstd/ext/graph/visual/graph_base_full_layout.cpp
@@ -5,6 +5,7 @@
 #include <hstd/ext/graph/visual/graph_avoid.hpp>
 #include <hstd/ext/graph/visual/graph_vpsc.hpp>
 #include <hstd/ext/geometry/hstd_geometry.hpp>
+#include <hstd/stdlib/SetFormatter.hpp>
 
 using namespace hstd::ext::graph;
 

--- a/src/hstd/ext/graph/visual/graph_elk.cpp
+++ b/src/hstd/ext/graph/visual/graph_elk.cpp
@@ -26,14 +26,14 @@ void elk::validate(elk::GraphElkLayoutData const& graph) {
 
             if (node_ids.contains(node.id)) {
                 throw hstd::runtime_error::init(
-                    std::format("Duplicate node id: '{}'", node.id));
+                    fmt::format("Duplicate node id: '{}'", node.id));
             }
             node_ids.insert(node.id);
 
             for (const auto& port : node.ports) {
                 if (port_ids.contains(port.id)) {
                     throw hstd::runtime_error::init(
-                        std::format("Duplicate port id: '{}'", node.id));
+                        fmt::format("Duplicate port id: '{}'", node.id));
                 }
                 port_ids.insert(port.id);
             }
@@ -46,7 +46,7 @@ void elk::validate(elk::GraphElkLayoutData const& graph) {
     for (const auto& port : graph.ports) {
         if (port_ids.contains(port.id)) {
             throw hstd::runtime_error::init(
-                std::format("Duplicate port id: '{}'", port.id));
+                fmt::format("Duplicate port id: '{}'", port.id));
         }
         port_ids.insert(port.id);
     }
@@ -59,14 +59,14 @@ void elk::validate(elk::GraphElkLayoutData const& graph) {
                 if (edge.id.empty()) { throw hstd::runtime_error::init("Empty edge ID"); }
                 if (edge_ids.contains(edge.id)) {
                     throw hstd::runtime_error::init(
-                        std::format("Duplicate edge id: '{}'", edge.id));
+                        fmt::format("Duplicate edge id: '{}'", edge.id));
                 }
                 edge_ids.insert(edge.id);
 
                 if (edge.source && !node_ids.contains(*edge.source)
                     && !port_ids.contains(*edge.source)) {
                     throw hstd::runtime_error::init(
-                        std::format(
+                        fmt::format(
                             "Edge '{}' references unknown source: '{}'",
                             edge.id,
                             *edge.source));
@@ -75,7 +75,7 @@ void elk::validate(elk::GraphElkLayoutData const& graph) {
                 if (edge.target && !node_ids.contains(*edge.target)
                     && !port_ids.contains(*edge.target)) {
                     throw hstd::runtime_error::init(
-                        std::format(
+                        fmt::format(
                             "Edge '{}' references unknown target: '{}'",
                             edge.id,
                             *edge.target));
@@ -83,7 +83,7 @@ void elk::validate(elk::GraphElkLayoutData const& graph) {
 
                 if (edge.sourcePort && !port_ids.contains(*edge.sourcePort)) {
                     throw hstd::runtime_error::init(
-                        std::format(
+                        fmt::format(
                             "Edge '{}' references unknown source port: "
                             "'{}'",
                             edge.id,
@@ -92,7 +92,7 @@ void elk::validate(elk::GraphElkLayoutData const& graph) {
 
                 if (edge.targetPort && !port_ids.contains(*edge.targetPort)) {
                     throw hstd::runtime_error::init(
-                        std::format(
+                        fmt::format(
                             "Edge '{}' references unknown target port: "
                             "'{}'",
                             edge.id,
@@ -102,7 +102,7 @@ void elk::validate(elk::GraphElkLayoutData const& graph) {
                 for (const auto& source : edge.sources) {
                     if (!node_ids.contains(source) && !port_ids.contains(source)) {
                         throw hstd::runtime_error::init(
-                            std::format(
+                            fmt::format(
                                 "Edge '{}' references unknown source: "
                                 "'{}'",
                                 edge.id,
@@ -113,7 +113,7 @@ void elk::validate(elk::GraphElkLayoutData const& graph) {
                 for (const auto& target : edge.targets) {
                     if (!node_ids.contains(target) && !port_ids.contains(target)) {
                         throw hstd::runtime_error::init(
-                            std::format(
+                            fmt::format(
                                 "Edge '{}' references unknown target: "
                                 "'{}'",
                                 edge.id,

--- a/src/hstd/ext/graph/visual/graph_elk.hpp
+++ b/src/hstd/ext/graph/visual/graph_elk.hpp
@@ -707,9 +707,11 @@ struct hstd::JsonSerde<hstd::ext::graph::elk::Options> {
 };
 
 template <>
-struct std::formatter<hstd::ext::graph::elk::Options> {
-    template <typename FormatContext>
-    auto format(hstd::ext::graph::elk::Options const& p, FormatContext& ctx) const {
+struct fmt::formatter<hstd::ext::graph::elk::Options> {
+
+    hstd::fmt_iter format(
+        hstd::ext::graph::elk::Options const& p,
+        fmt::format_context&                  ctx) const {
         return hstd::fmt_ctx(p.data, ctx);
     }
 };

--- a/src/hstd/ext/graph/visual/graph_elk.hpp
+++ b/src/hstd/ext/graph/visual/graph_elk.hpp
@@ -708,7 +708,7 @@ struct hstd::JsonSerde<hstd::ext::graph::elk::Options> {
 
 template <>
 struct fmt::formatter<hstd::ext::graph::elk::Options> {
-
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(
         hstd::ext::graph::elk::Options const& p,
         fmt::format_context&                  ctx) const {

--- a/src/hstd/ext/graph/visual/graph_graphviz.cpp
+++ b/src/hstd/ext/graph/visual/graph_graphviz.cpp
@@ -1,7 +1,6 @@
 #if !ORG_BUILD_EMCC && ORG_BUILD_WITH_CGRAPH
 #    include <hstd/ext/graph/visual/graph_graphviz.hpp>
 #    include <filesystem>
-#    include <format>
 #    include <hstd/ext/logger.hpp>
 #    include <hstd/stdlib/Debug.hpp>
 
@@ -208,7 +207,7 @@ gv::Record gv::Record::fromEscapedTextRow(Vec<Str> const& cells) {
 Str gv::Record::toString(bool braceCount) const {
     Str result;
     if (isFinal()) {
-        if (tag) { result += std::format("<{}>", *tag); }
+        if (tag) { result += fmt::format("<{}>", *tag); }
         result += gv::escape(getLabel());
     } else {
         auto const& c = getNested();

--- a/src/hstd/ext/graph/visual/graph_graphviz.hpp
+++ b/src/hstd/ext/graph/visual/graph_graphviz.hpp
@@ -431,7 +431,7 @@ struct GraphvizObjBase : CRTP_this_method<T> {
     }
 
     void setAttr(Str const& key, Point value) {
-        _this()->setAttr(key, std::format("{},{}", value.x(), value.y()));
+        _this()->setAttr(key, fmt::format("{},{}", value.x(), value.y()));
     }
 
     void setAttr(Str const& key, double value) {

--- a/src/hstd/ext/graph/visual/graph_kiwi.cpp
+++ b/src/hstd/ext/graph/visual/graph_kiwi.cpp
@@ -98,7 +98,7 @@ struct single_layout_run_state {
         static int kiwi_run_counter = 0;
         if (run->TraceState) {
             layout.to_graphviz(run->getAdjacentToTraceFile(
-                std::format("kiwi_solver_run_{}.png", hstd::fmt1(kiwi_run_counter))));
+                fmt::format("kiwi_solver_run_{}.png", hstd::fmt1(kiwi_run_counter))));
         }
 
 
@@ -107,7 +107,7 @@ struct single_layout_run_state {
 
         if (run->TraceState) {
             run->writeAdjacentToTraceFile(
-                std::format("kiwi_solver_run_{}.svg", hstd::fmt1(kiwi_run_counter)),
+                fmt::format("kiwi_solver_run_{}.svg", hstd::fmt1(kiwi_run_counter)),
                 layout.to_svg(hstd::fmt1(kiwi_run_counter)).to_string(2));
         }
         ++kiwi_run_counter;

--- a/src/hstd/ext/immer.hpp
+++ b/src/hstd/ext/immer.hpp
@@ -33,11 +33,11 @@ template <typename T>
 struct std::hash<immer::vector<T>> : hstd::std_indexable_hash<immer::vector<T>> {};
 
 template <typename T>
-struct std::formatter<immer::vector<T>>
+struct fmt::formatter<immer::vector<T>>
     : hstd::std_item_iterator_formatter<T, immer::vector<T>> {};
 
 template <typename T>
-struct std::formatter<hstd::ext::ImmVec<T>>
+struct fmt::formatter<hstd::ext::ImmVec<T>>
     : hstd::std_item_iterator_formatter<T, hstd::ext::ImmVec<T>> {};
 
 namespace hstd::ext {

--- a/src/hstd/ext/log_graph_tracker.cpp
+++ b/src/hstd/ext/log_graph_tracker.cpp
@@ -10,6 +10,7 @@
 #    include <hstd/ext/logger.hpp>
 #    include <hstd/stdlib/Formatter.hpp>
 #    include <hstd/ext/graph/visual/graph_graphviz.hpp>
+#    include <hstd/stdlib/VecFormatter.hpp>
 
 #    if ORG_BUILD_WITH_QT
 #        include <QMetaObject>
@@ -155,7 +156,7 @@ hstd::SPtr<hstd::ext::graph::gv::GraphGroup> graphviz_processor::get_graphviz(
 
     for (auto const& [name, info] : nodes) {
         if (info.is_cluster) {
-            std::string cluster_name = std::format("cluster_{}", name);
+            std::string cluster_name = fmt::format("cluster_{}", name);
             auto        cluster      = graph->newSubgraph(cluster_name);
             cluster->setLabel(name);
             clusters.insert_or_assign(name, cluster);
@@ -179,11 +180,11 @@ hstd::SPtr<hstd::ext::graph::gv::GraphGroup> graphviz_processor::get_graphviz(
 
         std::string label{};
         if (!call.jump_description.empty() && call.count > 1) {
-            label = std::format("{} ({})", call.jump_description, call.count);
+            label = fmt::format("{} ({})", call.jump_description, call.count);
         } else if (!call.jump_description.empty()) {
             label = call.jump_description;
         } else if (call.count > 1) {
-            label = std::format("({})", call.count);
+            label = fmt::format("({})", call.count);
         }
 
         if (!label.empty()) { edge->setLabel(label); }
@@ -202,7 +203,7 @@ std::string graphviz_processor::get_parent() {
 }
 
 void graphviz_processor::add_edge(std::string const& from, std::string const& to) {
-    std::string edge_key = std::format("{} -> {}", from, to);
+    std::string edge_key = fmt::format("{} -> {}", from, to);
     auto        it       = edges.find(edge_key);
     if (it != edges.end()) {
         if (it->second.jump_description == pending_jump) {
@@ -218,7 +219,7 @@ void graphviz_processor::add_edge(std::string const& from, std::string const& to
 }
 
 void hstd::log::graphviz_processor::track_signal_emit(signal_emit_info const& info) {
-    std::string full_name = std::format("{}", info.name);
+    std::string full_name = fmt::format("{}", info.name);
     if (!call_stack.empty()) { add_edge(call_stack.top(), full_name); }
     nodes.insert_or_assign(
         full_name,
@@ -229,7 +230,7 @@ void hstd::log::graphviz_processor::track_signal_emit(signal_emit_info const& in
 }
 
 void hstd::log::graphviz_processor::track_slot_trigger(slot_trigger_info const& info) {
-    std::string full_name = std::format("{}", info.name);
+    std::string full_name = fmt::format("{}", info.name);
     call_stack.push(full_name);
     nodes.insert_or_assign(
         full_name,

--- a/src/hstd/ext/log_graph_tracker.cpp
+++ b/src/hstd/ext/log_graph_tracker.cpp
@@ -11,6 +11,7 @@
 #    include <hstd/stdlib/Formatter.hpp>
 #    include <hstd/ext/graph/visual/graph_graphviz.hpp>
 #    include <hstd/stdlib/VecFormatter.hpp>
+#    include <hstd/stdlib/PairFormatter.hpp>
 
 #    if ORG_BUILD_WITH_QT
 #        include <QMetaObject>

--- a/src/hstd/ext/log_graph_tracker.hpp
+++ b/src/hstd/ext/log_graph_tracker.hpp
@@ -270,12 +270,12 @@ struct log_graph_tracker {
         hstd::Vec<hstd::Str> const& names,
         const Args&... args) {
         hstd::Vec<hstd::Pair<hstd::Str, hstd::Str>> result;
-        auto format_var = [](auto const& var) -> std::string {
+        hstd::fmt_iter format_var = [](auto const& var) -> std::string {
             using VarType = std::decay_t<decltype(var)>;
             if constexpr (hstd::log::has_log_value_formatter<VarType>) {
                 return hstd::log::log_value_formatter<VarType>{}.format(var);
             } else if constexpr (hstd::StdFormattable<VarType>) {
-                return std::format("{}", var);
+                return fmt::format("{}", var);
             } else {
                 return hstd::Str{"<type unformattable>"};
             }

--- a/src/hstd/ext/log_graph_tracker.hpp
+++ b/src/hstd/ext/log_graph_tracker.hpp
@@ -270,7 +270,7 @@ struct log_graph_tracker {
         hstd::Vec<hstd::Str> const& names,
         const Args&... args) {
         hstd::Vec<hstd::Pair<hstd::Str, hstd::Str>> result;
-        hstd::fmt_iter format_var = [](auto const& var) -> std::string {
+        auto format_var = [](auto const& var) -> std::string {
             using VarType = std::decay_t<decltype(var)>;
             if constexpr (hstd::log::has_log_value_formatter<VarType>) {
                 return hstd::log::log_value_formatter<VarType>{}.format(var);

--- a/src/hstd/ext/logger.cpp
+++ b/src/hstd/ext/logger.cpp
@@ -98,7 +98,7 @@ class log_sink_manager {
 
     void push_sink(sink_ptr sink) {
         if (OLOG_INNER_DEBUG) {
-            OLOG_MSG() << fmt(
+            OLOG_MSG() << hstd::fmt(
                 "Push shink {:p}, current sink stack is {}",
                 (void*)sink.get(),
                 sinks_.size());
@@ -113,7 +113,7 @@ class log_sink_manager {
         std::lock_guard<std::mutex> lock(m_);
         if (!sinks_.empty()) {
             if (OLOG_INNER_DEBUG) {
-                OLOG_MSG() << fmt(
+                OLOG_MSG() << hstd::fmt(
                     "Pop sink {:p}, current sink stack is {}",
                     (void*)sinks_.top().get(),
                     sinks_.size());
@@ -185,7 +185,7 @@ void format_log_record_data(
     std::string prefix;
 
     if (false) {
-        prefix += fmt(
+        prefix += hstd::fmt(
             "{}{}",
             ts ? boost::posix_time::to_simple_string(*ts).substr(
                      11, 9 /*Extract HH:MM:SS*/)
@@ -523,17 +523,19 @@ void hstd::log::log_record::end() {
 
 
 template <>
-struct std::formatter<boost::log::attribute_name> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(boost::log::attribute_name const& p, FormatContext& ctx) const {
+struct fmt::formatter<boost::log::attribute_name> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(boost::log::attribute_name const& p, fmt::format_context& ctx)
+        const {
         return fmt_ctx(p.string(), ctx);
     }
 };
 
 template <>
-struct std::formatter<boost::log::attribute_value> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(boost::log::attribute_value const& p, FormatContext& ctx) const {
+struct fmt::formatter<boost::log::attribute_value> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(boost::log::attribute_value const& p, fmt::format_context& ctx)
+        const {
         return fmt_ctx(p.get_type().pretty_name(), ctx);
     }
 };

--- a/src/hstd/ext/logger.cpp
+++ b/src/hstd/ext/logger.cpp
@@ -523,8 +523,8 @@ void hstd::log::log_record::end() {
 
 
 template <>
-struct fmt::formatter<boost::log::attribute_name> : fmt::formatter<std::string> {
-
+struct fmt::formatter<boost::log::attribute_name> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(boost::log::attribute_name const& p, fmt::format_context& ctx)
         const {
         return fmt_ctx(p.string(), ctx);
@@ -532,8 +532,8 @@ struct fmt::formatter<boost::log::attribute_name> : fmt::formatter<std::string> 
 };
 
 template <>
-struct fmt::formatter<boost::log::attribute_value> : fmt::formatter<std::string> {
-
+struct fmt::formatter<boost::log::attribute_value> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(boost::log::attribute_value const& p, fmt::format_context& ctx)
         const {
         return fmt_ctx(p.get_type().pretty_name(), ctx);

--- a/src/hstd/ext/logger.hpp
+++ b/src/hstd/ext/logger.hpp
@@ -105,8 +105,7 @@ auto format_logger_argument1(T const& arg) {
 
 template <typename... Args>
 std::string format_logger_arguments(LogFormatStr<Args...> fmt_str, Args const&... args) {
-    hstd::fmt_iter formatted_args = std::make_tuple(
-        format_logger_argument1<Args>(args)...);
+    auto formatted_args = std::make_tuple(format_logger_argument1<Args>(args)...);
     return std::apply(
         [&fmt_str](auto const&... args_ref) { return fmt::format(fmt_str, args_ref...); },
         formatted_args);

--- a/src/hstd/ext/logger.hpp
+++ b/src/hstd/ext/logger.hpp
@@ -86,16 +86,16 @@ concept has_log_value_formatter = requires(T const& value) {
 };
 
 template <typename... Args>
-using LogFormatStr = std::format_string<std::conditional_t<
+using LogFormatStr = fmt::format_string<std::conditional_t<
     hstd::log::has_log_value_formatter<std::decay_t<Args>>,
     std::string,
     std::conditional_t<hstd::StdFormattable<std::decay_t<Args>>, Args, std::string>>...>;
 
 template <typename T>
 auto format_logger_argument1(T const& arg) {
-    if constexpr (hstd::log::has_log_value_formatter<std::decay_t<decltype(arg)>>) {
-        return hstd::log::log_value_formatter<std::decay_t<decltype(arg)>>{}.format(arg);
-    } else if constexpr (hstd::StdFormattable<std::decay_t<decltype(arg)>>) {
+    if constexpr (hstd::log::has_log_value_formatter<std::decay_t<T>>) {
+        return hstd::log::log_value_formatter<std::decay_t<T>>{}.format(arg);
+    } else if constexpr (hstd::StdFormattable<std::decay_t<T>>) {
         return arg;
     } else {
         return hstd::fmt(
@@ -104,15 +104,13 @@ auto format_logger_argument1(T const& arg) {
 }
 
 template <typename... Args>
-std::string format_logger_arguments(LogFormatStr<Args...> __fmt, const Args&... args) {
-    auto formatted_args = std::make_tuple(format_logger_argument1<Args>(args)...);
+std::string format_logger_arguments(LogFormatStr<Args...> fmt_str, Args const&... args) {
+    hstd::fmt_iter formatted_args = std::make_tuple(
+        format_logger_argument1<Args>(args)...);
     return std::apply(
-        [&__fmt](auto&... args_ref) {
-            return std::vformat(__fmt.get(), std::make_format_args(args_ref...));
-        },
+        [&fmt_str](auto const&... args_ref) { return fmt::format(fmt_str, args_ref...); },
         formatted_args);
 }
-
 
 enum class severity_level
 {
@@ -244,8 +242,9 @@ struct log_record {
         log_category const&   category,
         LogFormatStr<Args...> fmt,
         Args&&... args) {
-        log_record rec;
-        auto formatted_args = std::make_tuple(format_logger_argument1<Args>(args)...);
+        log_record     rec;
+        hstd::fmt_iter formatted_args = std::make_tuple(
+            format_logger_argument1<Args>(args)...);
         rec.line(line)
             .file(file)
             .severity(severity)
@@ -254,7 +253,7 @@ struct log_record {
             .message(
                 std::apply(
                     [&fmt](auto&... args_ref) {
-                        return std::vformat(
+                        return fmt::vformat(
                             fmt.get(), std::make_format_args(args_ref...));
                     },
                     formatted_args));
@@ -274,7 +273,8 @@ struct log_record {
         rec.line(line).file(file).severity(severity).function(function).message(
             std::apply(
                 [&fmt](auto&... args_ref) {
-                    return std::vformat(fmt.get(), std::make_format_args(args_ref...));
+                    auto store = fmt::make_format_args(args_ref...);
+                    return fmt::vformat(fmt.get(), fmt::format_args(store));
                 },
                 formatted_args));
         return rec;
@@ -332,9 +332,10 @@ struct log_record {
 
     template <typename... _Args>
     inline log_record& fmt_message(
-        std::format_string<_Args...> __fmt,
+        fmt::format_string<_Args...> __fmt,
         _Args&&... __args) {
-        data.message += std::vformat(__fmt.get(), std::make_format_args(__args...));
+        auto store = fmt::make_format_args(__args...);
+        data.message += fmt::vformat(__fmt.get(), fmt::format_args(store));
         return *this;
     }
 
@@ -439,7 +440,7 @@ struct log_builder {
     template <typename Self, typename... _Args>
     inline auto&& fmt_message(
         this Self&&                  self,
-        std::format_string<_Args...> __fmt,
+        fmt::format_string<_Args...> __fmt,
         _Args&&... __args) {
         if (!self.is_released) {
             self.rec.fmt_message(__fmt, std::forward<_Args>(__args)...);
@@ -720,7 +721,7 @@ std::string __HSLOG_DEBUG_FMT_EXPR_IMPL_impl(
     int names_width = 0;
     for (auto const& n : argNames) { names_width = std::max<int>(names_width, n.size()); }
 
-    auto format_arg = [&](int index, auto const& value) {
+    hstd::fmt_iter format_arg = [&](int index, auto const& value) {
         if (index > 0) {
             if (stack) {
                 result += "\n";

--- a/src/hstd/ext/logger.hpp
+++ b/src/hstd/ext/logger.hpp
@@ -107,7 +107,10 @@ template <typename... Args>
 std::string format_logger_arguments(LogFormatStr<Args...> fmt_str, Args const&... args) {
     auto formatted_args = std::make_tuple(format_logger_argument1<Args>(args)...);
     return std::apply(
-        [&fmt_str](auto const&... args_ref) { return fmt::format(fmt_str, args_ref...); },
+        [&fmt_str](auto const&... args_ref) {
+            return fmt::vformat(
+                fmt::string_view(fmt_str.get()), fmt::make_format_args(args_ref...));
+        },
         formatted_args);
 }
 

--- a/src/hstd/ext/textlayouter.cpp
+++ b/src/hstd/ext/textlayouter.cpp
@@ -9,6 +9,8 @@
 #include <hstd/stdlib/Formatter.hpp>
 #include <hstd/stdlib/Ranges.hpp>
 #include <hstd/stdlib/Formatter.hpp>
+#include <sstream>
+#include <hstd/stdlib/VecFormatter.hpp>
 
 using namespace hstd::layout;
 using namespace hstd;

--- a/src/hstd/stdlib/Array.hpp
+++ b/src/hstd/stdlib/Array.hpp
@@ -117,14 +117,12 @@ struct TypArray : public Array<Val, pow_v<2, 8 * sizeof(Key)>::res> {
 } // namespace hstd
 
 template <typename T, int Size>
-struct std::formatter<hstd::Array<T, Size>> : std::formatter<std::string> {
-    template <typename FormatContext>
-    typename FormatContext::iterator format(
-        hstd::Array<T, Size> const& p,
-        FormatContext&              ctx) const {
-        std::formatter<std::string> fmt;
-        fmt.format("[", ctx);
-        fmt.format(join(", ", p), ctx);
-        return fmt.format("]", ctx);
+struct fmt::formatter<hstd::Array<T, Size>> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+
+    hstd::fmt_iter format(hstd::Array<T, Size> const& p, fmt::format_context& ctx) const {
+        ::hstd::fmt_ctx("[", ctx);
+        ::hstd::fmt_ctx(join(", ", p), ctx);
+        return ::hstd::fmt_ctx("]", ctx);
     }
 };

--- a/src/hstd/stdlib/BackwardsIndex.hpp
+++ b/src/hstd/stdlib/BackwardsIndex.hpp
@@ -1,6 +1,6 @@
 #pragma once
+#include <fmt/base.h>
 #pragma clang diagnostic ignored "-Wunknown-attributes"
-#include <format>
 
 namespace hstd {
 struct [[refl]] BackwardsIndex {
@@ -25,12 +25,14 @@ inline BackwardsIndex backIndex(int value) { return BackwardsIndex{.value = valu
 } // namespace hstd
 
 template <>
-struct std::formatter<hstd::BackwardsIndex> : std::formatter<std::string> {
+struct fmt::formatter<hstd::BackwardsIndex> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+
     using FmtType = hstd::BackwardsIndex;
-    template <typename FormatContext>
-    FormatContext::iterator format(FmtType const& p, FormatContext& ctx) const {
-        std::formatter<std::string> fmt;
-        return fmt.format("^" + std::to_string(p.value), ctx);
+    fmt::format_context::iterator format(FmtType const& p, fmt::format_context& ctx)
+        const {
+        fmt::format_to(ctx.out(), "^");
+        return fmt::format_to(ctx.out(), "{}", p.value);
     }
 };
 

--- a/src/hstd/stdlib/ColText.cpp
+++ b/src/hstd/stdlib/ColText.cpp
@@ -240,7 +240,7 @@ void hstd::hshow<std::string_view>::format(
                 for (Str const& it : visibleUnicodeName(value, !opts.get_use_ascii())) {
                     if (!first) { os << " "; }
                     first = false;
-                    os << std::format("{}{}{}", open_quote, it, close_quote);
+                    os << fmt::format("{}{}{}", open_quote, it, close_quote);
                 }
             } else {
                 for (const auto& it : visibleUnicodeName(value, !opts.get_use_ascii())) {
@@ -343,7 +343,7 @@ std::string hstd::to_colored_html(Vec<ColRune> const& runes) {
         if (s2.fg != s1.fg) {
             if (!isDefault(s1.fg)) { close_tags += "</font>"; }
             if (!isDefault(s2.fg)) {
-                open_tags += std::format("<font color=\"{}\">", toHtmlColor(s2.fg));
+                open_tags += fmt::format("<font color=\"{}\">", toHtmlColor(s2.fg));
             }
         }
 

--- a/src/hstd/stdlib/ColTextFormatter.hpp
+++ b/src/hstd/stdlib/ColTextFormatter.hpp
@@ -5,9 +5,9 @@
 
 
 template <>
-struct std::formatter<hstd::ColRune> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(hstd::ColRune const& p, FormatContext& ctx) const {
+struct fmt::formatter<hstd::ColRune> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+    hstd::fmt_iter format(hstd::ColRune const& p, fmt::format_context& ctx) const {
         hstd::fmt_ctx("{", ctx);
         hstd::fmt_ctx(p.rune, ctx);
         if (p.style.fg != (hstd::TermColorFg8Bit)0) {
@@ -31,9 +31,9 @@ struct std::formatter<hstd::ColRune> : std::formatter<std::string> {
 
 
 template <>
-struct std::formatter<hstd::ColText> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(hstd::ColText const& p, FormatContext& ctx) const {
-        return std::formatter<std::string>{}.format(p.toString(false), ctx);
+struct fmt::formatter<hstd::ColText> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+    hstd::fmt_iter format(hstd::ColText const& p, fmt::format_context& ctx) const {
+        return fmt::formatter<std::string>{}.format(p.toString(false), ctx);
     }
 };

--- a/src/hstd/stdlib/ColTextFormatter.hpp
+++ b/src/hstd/stdlib/ColTextFormatter.hpp
@@ -34,6 +34,6 @@ template <>
 struct fmt::formatter<hstd::ColText> {
     constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(hstd::ColText const& p, fmt::format_context& ctx) const {
-        return fmt::formatter<std::string>{}.format(p.toString(false), ctx);
+        return hstd::fmt_ctx(p.toString(false), ctx);
     }
 };

--- a/src/hstd/stdlib/ColTextHShow.hpp
+++ b/src/hstd/stdlib/ColTextHShow.hpp
@@ -94,7 +94,7 @@ struct hshow {};
 template <StdFormattable T>
 struct hshow_std_format {
     static void format(ColStream& s, T const& value, hshow_opts const& opts) {
-        s << std::format("{}", value);
+        s << fmt::format("{}", value);
     }
 };
 
@@ -117,11 +117,11 @@ struct hshow_integral_type {
     static void format(ColStream& s, T const& value, hshow_opts const& opts) {
         s << s.blue();
         if (opts.get_use_hex()) {
-            s << std::format("{:X}", value);
+            s << fmt::format("{:X}", value);
         } else if (opts.get_use_bin()) {
-            s << std::format("{:B}", value);
+            s << fmt::format("{:B}", value);
         } else {
-            s << std::format("{}", value);
+            s << fmt::format("{}", value);
         }
         s << s.end();
     }

--- a/src/hstd/stdlib/Debug.hpp
+++ b/src/hstd/stdlib/Debug.hpp
@@ -9,7 +9,7 @@
 
 void setMessageStream(std::ostream& stream);
 
-#define __fmt_location() std::format("{}:{} {}", __FILE__, __LINE__, __FUNCTION__)
+#define __fmt_location() fmt::format("{}:{} {}", __FILE__, __LINE__, __FUNCTION__)
 
 #define _dbg(expr)                                                                       \
     ([](auto const& it, char const* __base_function) {                                   \
@@ -31,7 +31,7 @@ void setMessageStream(std::ostream& stream);
               << std::endl;
 
 #define _dfmt_expr_impl(_1, _2, arg)                                                     \
-    +std::string{" "} + BOOST_PP_STRINGIZE(arg) + fmt(" = ⦃{}⦄", arg)
+    +std::string{" "} + BOOST_PP_STRINGIZE(arg) + ::hstd::fmt(" = ⦃{}⦄", arg)
 
 
 /// \brief Format all values to string `<expr1> = ⦃<value1>⦄ <expr2> =

--- a/src/hstd/stdlib/Filesystem.cpp
+++ b/src/hstd/stdlib/Filesystem.cpp
@@ -49,7 +49,7 @@ void hstd::writeDebugFile(
     char const*        function,
     char const*        file) {
     auto        filename  = fs::path{file}.stem();
-    std::string full_path = fmt(
+    std::string full_path = hstd::fmt(
         "/tmp/{}_{}{}.{}", filename, function, stem_suffix, extension);
 
     writeFile(full_path, content);

--- a/src/hstd/stdlib/Filesystem.hpp
+++ b/src/hstd/stdlib/Filesystem.hpp
@@ -46,10 +46,10 @@ std::string readFile(fs::path const& target);
 
 
 template <>
-struct fmt::formatter<hstd::fs::path> : fmt::formatter<std::string> {
-    using FmtType = hstd::fs::path;
+struct fmt::formatter<hstd::fs::path> {
     constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
-    auto           format(FmtType const& p, fmt::format_context& ctx) const {
+
+    hstd::fmt_iter format(hstd::fs::path const& p, fmt::format_context& ctx) const {
         return hstd::fmt_ctx(p.native(), ctx);
     }
 };

--- a/src/hstd/stdlib/Filesystem.hpp
+++ b/src/hstd/stdlib/Filesystem.hpp
@@ -4,7 +4,6 @@
 #include <string>
 #include <filesystem>
 #include <hstd/stdlib/Ptrs.hpp>
-#include <format>
 #include <hstd/system/exceptions.hpp>
 
 namespace hstd {
@@ -47,11 +46,10 @@ std::string readFile(fs::path const& target);
 
 
 template <>
-struct std::formatter<hstd::fs::path> : std::formatter<std::string> {
+struct fmt::formatter<hstd::fs::path> : fmt::formatter<std::string> {
     using FmtType = hstd::fs::path;
-    template <typename FormatContext>
-    FormatContext::iterator format(FmtType const& p, FormatContext& ctx) const {
-        std::formatter<std::string> fmt;
-        return fmt.format(p.native(), ctx);
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+    auto           format(FmtType const& p, fmt::format_context& ctx) const {
+        return hstd::fmt_ctx(p.native(), ctx);
     }
 };

--- a/src/hstd/stdlib/Formatter.hpp
+++ b/src/hstd/stdlib/Formatter.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
-#include <format>
+#include <fmt/base.h>
+#include <fmt/core.h>
+#include <fmt/format.h>
 #include <hstd/system/reflection.hpp>
 #include <hstd/system/string_convert.hpp>
 
@@ -8,62 +10,62 @@ namespace hstd {
 
 
 template <typename T, typename CharT>
-using Fmt = ::std::formatter<T, CharT>;
+using Fmt = ::fmt::formatter<T, CharT>;
+
+using fmt_iter = fmt::format_context::iterator;
 
 /// \brief Early-fail the instantiation if the formatter is
 /// invalid. This function is a no-op at runtime and serves only for the
 /// developer's sanity to make the formatter failures more apparent.
 template <typename T>
 void with_std_formatter(T const& value) {
-    if (false) {
-        std::format_context*     ctx;
-        std::formatter<T> const* fmt;
-        auto                     result = fmt->format(value, *ctx);
-        static_assert(std::is_same_v<decltype(result), std::format_context::iterator>);
-    }
+    static_assert(fmt::is_formattable<T>::value);
+    // if (false) {
+    //     fmt::format_context*     ctx;
+    //     fmt::formatter<T> const* fmt;
+    //     auto                     result = fmt->format(value, *ctx);
+    //     static_assert(std::is_same_v<decltype(result), fmt::format_context::iterator>);
+    // }
 }
 
-template <typename... _Args>
-[[nodiscard]] inline std::string fmt(
-    std::format_string<_Args...> __fmt,
-    _Args&&... __args) {
-    return std::vformat(__fmt.get(), std::make_format_args(__args...));
+template <typename... Args>
+[[nodiscard]] inline std::string fmt(fmt::format_string<Args...> format, Args&&... args) {
+    return fmt::vformat(format.get(), fmt::make_format_args(args...));
 }
 
 template <typename T>
 std::string fmt1(T const& t) {
     with_std_formatter(t);
-    return std::format("{}", t);
+    return fmt::format("{}", t);
 }
 
 template <hstd::StdFormattable T>
 std::string fmt1_maybe(T const& t) {
-    return std::format("{}", t);
+    return fmt::format("{}", t);
 }
 
 template <typename T>
 std::string fmt1_maybe([[maybe_unused]] T const& t) {
-    return std::format("[not formattable {}]", hstd::value_metadata<T>::typeName());
+    return fmt::format("[not formattable {}]", hstd::value_metadata<T>::typeName());
 }
 
 
-template <typename T, typename FormatContext>
-FormatContext::iterator fmt_ctx(T const& t, FormatContext& ctx) {
+template <typename T>
+fmt::format_context::iterator fmt_ctx(T const& t, fmt::format_context& ctx) {
     with_std_formatter(t);
-    return std::formatter<T>{}.format(t, ctx);
+    return fmt::format_to(ctx.out(), "{}", t);
 }
 
 
-template <typename FormatContext>
-FormatContext::iterator fmt_ctx(char const* t, FormatContext& ctx) {
+fmt::format_context::iterator fmt_ctx(char const* t, fmt::format_context& ctx) {
     with_std_formatter(t);
-    return std::formatter<std::string>{}.format(t, ctx);
+    return fmt::format_to(ctx.out(), "{}", t);
 }
 
 template <typename T>
-struct std_format_ptr_as_value : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(T const* p, FormatContext& ctx) const {
+struct std_format_ptr_as_value {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+    auto           format(T const* p, fmt::format_context& ctx) const {
         if (p == nullptr) {
             return fmt_ctx("nullptr", ctx);
         } else {
@@ -74,34 +76,34 @@ struct std_format_ptr_as_value : std::formatter<std::string> {
 
 
 template <typename T>
-struct std_format_ptr_as_hex : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(T const* p, FormatContext& ctx) const {
+struct std_format_ptr_as_hex {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+    auto           format(T const* p, fmt::format_context& ctx) const {
         if (p == nullptr) {
             return fmt_ctx("nullptr", ctx);
         } else {
-            return fmt_ctx(std::format("{:p}", static_cast<const void*>(p)), ctx);
+            return fmt_ctx(fmt::format("{:p}", static_cast<const void*>(p)), ctx);
         }
     }
 };
 
 template <typename T>
-struct std_format_ptr_as_hex_and_value : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(T const* p, FormatContext& ctx) const {
+struct std_format_ptr_as_hex_and_value {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+    auto           format(T const* p, fmt::format_context& ctx) const {
         if (p == nullptr) {
             return fmt_ctx("nullptr", ctx);
         } else {
-            fmt_ctx(std::format("{:p}->", static_cast<const void*>(p)), ctx);
+            fmt_ctx(fmt::format("{:p}->", static_cast<const void*>(p)), ctx);
             return fmt_ctx(*p, ctx);
         }
     }
 };
 
 template <typename T, typename Container>
-struct std_item_iterator_formatter : std::formatter<std::string> {
-    template <typename FormatContext>
-    FormatContext::iterator format(Container const& p, FormatContext& ctx) const {
+struct std_item_iterator_formatter {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+    auto           format(Container const& p, fmt::format_context& ctx) const {
         fmt_ctx("[", ctx);
         bool first = true;
         for (const auto& value : p) {
@@ -114,9 +116,9 @@ struct std_item_iterator_formatter : std::formatter<std::string> {
 };
 
 template <typename K, typename V, typename Type>
-struct std_kv_tuple_iterator_formatter : std::formatter<std::string> {
-    template <typename FormatContext>
-    FormatContext::iterator format(Type const& p, FormatContext& ctx) const {
+struct std_kv_tuple_iterator_formatter {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+    auto           format(Type const& p, fmt::format_context& ctx) const {
         fmt_ctx("{", ctx);
         bool first = true;
         for (const auto& [key, value] : p) {
@@ -132,25 +134,24 @@ struct std_kv_tuple_iterator_formatter : std::formatter<std::string> {
 
 
 template <typename T, typename Set>
-struct std_unordered_sequence_formatter : std::formatter<std::string> {
-    template <typename FormatContext>
-    FormatContext::iterator format(Set const& p, FormatContext& ctx) const {
-        std::formatter<std::string> fmt;
-        fmt.format("{", ctx);
+struct std_unordered_sequence_formatter {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+    auto           format(Set const& p, fmt::format_context& ctx) const {
+        ::hstd::fmt_ctx("{", ctx);
         bool first = true;
         for (const auto& it : p) {
-            if (!first) { fmt.format(", ", ctx); }
+            if (!first) { hstd::fmt_ctx(", ", ctx); }
             first = false;
-            fmt_ctx(it, ctx);
+            hstd::fmt_ctx(it, ctx);
         }
-        return fmt.format("}", ctx);
+        return hstd::fmt_ctx("}", ctx);
     }
 };
 
 template <typename T>
-struct std_strong_typedef_formatter : std::formatter<std::string> {
-    template <typename FormatContext>
-    FormatContext::iterator format(T const& p, FormatContext& ctx) const {
+struct std_strong_typedef_formatter {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+    auto           format(T const& p, fmt::format_context& ctx) const {
         hstd::fmt_ctx(hstd::value_metadata<T>::typeName(), ctx);
         hstd::fmt_ctx("(", ctx);
         hstd::fmt_ctx(p.t, ctx);
@@ -161,23 +162,24 @@ struct std_strong_typedef_formatter : std::formatter<std::string> {
 } // namespace hstd
 
 template <>
-struct std::formatter<int const*> : hstd::std_format_ptr_as_value<int> {};
+struct fmt::formatter<int const*> : hstd::std_format_ptr_as_value<int> {};
 
 template <>
-struct std::formatter<int*> : hstd::std_format_ptr_as_value<int> {};
+struct fmt::formatter<int*> : hstd::std_format_ptr_as_value<int> {};
 
 template <typename T>
-struct std::formatter<std::reference_wrapper<T>> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(std::reference_wrapper<T> const& p, FormatContext& ctx) const {
+struct fmt::formatter<std::reference_wrapper<T>> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+    hstd::fmt_iter format(std::reference_wrapper<T> const& p, fmt::format_context& ctx)
+        const {
         return fmt_ctx(p.get(), ctx);
     }
 };
 
 template <hstd::DescribedRecord R>
-struct std::formatter<R> : std::formatter<std::string> {
-    template <typename FormatContext>
-    FormatContext::iterator format(R const& p, FormatContext& ctx) const {
+struct fmt::formatter<R> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+    auto           format(R const& p, fmt::format_context& ctx) const {
         bool first = true;
         ::hstd::fmt_ctx("{", ctx);
         ::hstd::for_each_field_value_with_bases(

--- a/src/hstd/stdlib/Formatter.hpp
+++ b/src/hstd/stdlib/Formatter.hpp
@@ -70,8 +70,7 @@ fmt::format_context::iterator fmt_ctx(T const& t, fmt::format_context& ctx) {
 }
 
 
-fmt::format_context::iterator fmt_ctx(char const* t, fmt::format_context& ctx) {
-    with_std_formatter(t);
+inline fmt::format_context::iterator fmt_ctx(char const* t, fmt::format_context& ctx) {
     return fmt::format_to(ctx.out(), "{}", t);
 }
 

--- a/src/hstd/stdlib/Formatter.hpp
+++ b/src/hstd/stdlib/Formatter.hpp
@@ -51,9 +51,22 @@ std::string fmt1_maybe([[maybe_unused]] T const& t) {
 
 
 template <typename T>
+concept has_exact_pointer_formatter //
+    = std::is_pointer_v<T> && requires(T const& value, fmt::format_context& ctx) {
+          {
+              fmt::formatter<T>{}.format(value, ctx)
+          } -> std::same_as<fmt::format_context::iterator>;
+      };
+
+template <typename T>
 fmt::format_context::iterator fmt_ctx(T const& t, fmt::format_context& ctx) {
-    with_std_formatter(t);
-    return fmt::format_to(ctx.out(), "{}", t);
+    if constexpr (has_exact_pointer_formatter<T>) {
+        fmt::formatter<T> formatter;
+        return formatter.format(t, ctx);
+    } else {
+        with_std_formatter(t);
+        return fmt::format_to(ctx.out(), "{}", t);
+    }
 }
 
 

--- a/src/hstd/stdlib/IntSet.hpp
+++ b/src/hstd/stdlib/IntSet.hpp
@@ -189,13 +189,13 @@ struct [[refl(R"({
 } // namespace hstd
 
 template <typename T>
-struct std::formatter<hstd::IntSet<T>> : std::formatter<std::string> {
+struct fmt::formatter<hstd::IntSet<T>> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+
     using FmtType = hstd::IntSet<T>;
-    template <typename FormatContext>
-    FormatContext::iterator format(FmtType const& p, FormatContext& ctx) const {
-        std::formatter<std::string> fmt;
-        fmt.format("{", ctx);
-        fmt.format(join(", ", p), ctx);
-        return fmt.format("}", ctx);
+    hstd::fmt_iter format(FmtType const& p, fmt::format_context& ctx) const {
+        hstd::fmt_ctx("{", ctx);
+        hstd::fmt_ctx(join(", ", p), ctx);
+        return hstd::fmt_ctx("}", ctx);
     }
 };

--- a/src/hstd/stdlib/JsonCLIParser.hpp
+++ b/src/hstd/stdlib/JsonCLIParser.hpp
@@ -3,6 +3,7 @@
 #include <hstd/stdlib/Filesystem.hpp>
 #include <hstd/stdlib/Exception.hpp>
 #include <hstd/stdlib/JsonSerde.hpp>
+#include <hstd/stdlib/VecFormatter.hpp>
 
 namespace hstd {
 template <typename T>

--- a/src/hstd/stdlib/JsonCLIParser.hpp
+++ b/src/hstd/stdlib/JsonCLIParser.hpp
@@ -9,10 +9,10 @@ template <typename T>
 T parse_json_argc(int argc, char const** argv) {
     if (argc != 2) {
         std::vector<std::string> argv_v;
-        for (int i = 0; i < argc; ++i) { argv_v.push_back(std::format("'{}'", argv[i])); }
+        for (int i = 0; i < argc; ++i) { argv_v.push_back(fmt::format("'{}'", argv[i])); }
 
         throw hstd::runtime_error::init(
-            std::format(
+            fmt::format(
                 "Expected exactly one CLI argument: JSON literal for the "
                 "configuration or a path to the JSON file. argc={} "
                 "argv={}",
@@ -25,7 +25,7 @@ T parse_json_argc(int argc, char const** argv) {
     if (std::string{argv[1]}.starts_with("/")) {
         if (!hstd::fs::exists(argv[1])) {
             throw std::logic_error(
-                std::format("Input configuration file '{}' does not exist", argv[1]));
+                fmt::format("Input configuration file '{}' does not exist", argv[1]));
         }
         json_parameters = hstd::readFile(argv[1]);
     } else {

--- a/src/hstd/stdlib/JsonUse.hpp
+++ b/src/hstd/stdlib/JsonUse.hpp
@@ -9,9 +9,9 @@
 
 
 template <>
-struct std::formatter<json> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(json const& p, FormatContext& ctx) const {
+struct fmt::formatter<json> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(json const& p, fmt::format_context& ctx) const {
         return hstd::fmt_ctx(p.dump(), ctx);
     }
 };

--- a/src/hstd/stdlib/JsonUse.hpp
+++ b/src/hstd/stdlib/JsonUse.hpp
@@ -9,8 +9,8 @@
 
 
 template <>
-struct fmt::formatter<json> : fmt::formatter<std::string> {
-
+struct fmt::formatter<json> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(json const& p, fmt::format_context& ctx) const {
         return hstd::fmt_ctx(p.dump(), ctx);
     }

--- a/src/hstd/stdlib/MapFormatter.hpp
+++ b/src/hstd/stdlib/MapFormatter.hpp
@@ -5,18 +5,18 @@
 
 
 template <typename K, typename V>
-struct std::formatter<std::unordered_map<K, V>>
+struct fmt::formatter<std::unordered_map<K, V>>
     : hstd::std_kv_tuple_iterator_formatter<K, V, std::unordered_map<K, V>> {};
 
 template <typename K, typename V>
-struct std::formatter<std::map<K, V>>
+struct fmt::formatter<std::map<K, V>>
     : hstd::std_kv_tuple_iterator_formatter<K, V, std::map<K, V>> {};
 
 
 template <typename K, typename V>
-struct std::formatter<hstd::UnorderedMap<K, V>>
+struct fmt::formatter<hstd::UnorderedMap<K, V>>
     : hstd::std_kv_tuple_iterator_formatter<K, V, hstd::UnorderedMap<K, V>> {};
 
 template <typename K, typename V, typename _Compare>
-struct std::formatter<hstd::SortedMap<K, V, _Compare>>
+struct fmt::formatter<hstd::SortedMap<K, V, _Compare>>
     : hstd::std_kv_tuple_iterator_formatter<K, V, hstd::SortedMap<K, V, _Compare>> {};

--- a/src/hstd/stdlib/OptFormatter.hpp
+++ b/src/hstd/stdlib/OptFormatter.hpp
@@ -4,10 +4,9 @@
 #include <hstd/stdlib/Formatter.hpp>
 
 template <typename T>
-struct fmt::formatter<hstd::Opt<T>> : fmt::formatter<std::string> {
-
+struct fmt::formatter<hstd::Opt<T>> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(hstd::Opt<T> const& p, fmt::format_context& ctx) const {
-        fmt::formatter<std::string> fmt;
         if (p.has_value()) {
             ::hstd::fmt_ctx("some(", ctx);
             ::hstd::fmt_ctx(p.value(), ctx);
@@ -19,8 +18,8 @@ struct fmt::formatter<hstd::Opt<T>> : fmt::formatter<std::string> {
 };
 
 template <>
-struct fmt::formatter<std::nullopt_t> : fmt::formatter<std::string> {
-
+struct fmt::formatter<std::nullopt_t> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(std::nullopt_t const& p, fmt::format_context& ctx) const {
         return ::hstd::fmt_ctx("nullopt", ctx);
     }

--- a/src/hstd/stdlib/OptFormatter.hpp
+++ b/src/hstd/stdlib/OptFormatter.hpp
@@ -4,10 +4,10 @@
 #include <hstd/stdlib/Formatter.hpp>
 
 template <typename T>
-struct std::formatter<hstd::Opt<T>> : std::formatter<std::string> {
-    template <typename FormatContext>
-    FormatContext::iterator format(hstd::Opt<T> const& p, FormatContext& ctx) const {
-        std::formatter<std::string> fmt;
+struct fmt::formatter<hstd::Opt<T>> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(hstd::Opt<T> const& p, fmt::format_context& ctx) const {
+        fmt::formatter<std::string> fmt;
         if (p.has_value()) {
             ::hstd::fmt_ctx("some(", ctx);
             ::hstd::fmt_ctx(p.value(), ctx);
@@ -19,9 +19,9 @@ struct std::formatter<hstd::Opt<T>> : std::formatter<std::string> {
 };
 
 template <>
-struct std::formatter<std::nullopt_t> : std::formatter<std::string> {
-    template <typename FormatContext>
-    FormatContext::iterator format(std::nullopt_t const& p, FormatContext& ctx) const {
+struct fmt::formatter<std::nullopt_t> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(std::nullopt_t const& p, fmt::format_context& ctx) const {
         return ::hstd::fmt_ctx("nullopt", ctx);
     }
 };

--- a/src/hstd/stdlib/Pair.hpp
+++ b/src/hstd/stdlib/Pair.hpp
@@ -3,20 +3,12 @@
 #include <utility>
 #include <hstd/system/reflection.hpp>
 
+
 namespace hstd {
 
 template <typename A, typename B>
 using Pair = std::pair<A, B>;
 
-
-template <typename Tuple, std::size_t... Is, typename FormatContext>
-auto format_tuple_impl(Tuple const& t, FormatContext& ctx, std::index_sequence<Is...>) {
-    fmt_ctx("(", ctx);
-    (...,
-     (fmt_ctx(std::get<Is>(t), ctx),
-      fmt_ctx((Is + 1 == sizeof...(Is) ? "" : ", "), ctx)));
-    return fmt_ctx(")", ctx);
-}
 
 template <typename T>
 Pair<T, T> pair1(T const& first, T const& second) {

--- a/src/hstd/stdlib/PairFormatter.hpp
+++ b/src/hstd/stdlib/PairFormatter.hpp
@@ -3,10 +3,25 @@
 #include <hstd/stdlib/Pair.hpp>
 #include <hstd/stdlib/Formatter.hpp>
 
+namespace hstd {
+template <typename Tuple, std::size_t... Is, typename FormatContext>
+hstd::fmt_iter format_tuple_impl(
+    Tuple const&         t,
+    fmt::format_context& ctx,
+    std::index_sequence<Is...>) {
+    ::hstd::fmt_ctx("(", ctx);
+    (...,
+     (::hstd::fmt_ctx(std::get<Is>(t), ctx),
+      ::hstd::fmt_ctx((Is + 1 == sizeof...(Is) ? "" : ", "), ctx)));
+    return ::hstd::fmt_ctx(")", ctx);
+}
+
+} // namespace hstd
+
 template <typename A, typename B>
-struct std::formatter<hstd::Pair<A, B>> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(hstd::Pair<A, B> const& p, FormatContext& ctx) const {
+struct fmt::formatter<hstd::Pair<A, B>> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(hstd::Pair<A, B> const& p, fmt::format_context& ctx) const {
         ::hstd::fmt_ctx("(", ctx);
         ::hstd::fmt_ctx(p.first, ctx);
         ::hstd::fmt_ctx(", ", ctx);
@@ -16,9 +31,9 @@ struct std::formatter<hstd::Pair<A, B>> : std::formatter<std::string> {
 };
 
 template <typename... Args>
-struct std::formatter<std::tuple<Args...>> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(std::tuple<Args...> const& t, FormatContext& ctx) const {
+struct fmt::formatter<std::tuple<Args...>> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(std::tuple<Args...> const& t, fmt::format_context& ctx) const {
         return ::hstd::format_tuple_impl(t, ctx, std::index_sequence_for<Args...>{});
     }
 };

--- a/src/hstd/stdlib/PairFormatter.hpp
+++ b/src/hstd/stdlib/PairFormatter.hpp
@@ -4,7 +4,7 @@
 #include <hstd/stdlib/Formatter.hpp>
 
 namespace hstd {
-template <typename Tuple, std::size_t... Is, typename FormatContext>
+template <typename Tuple, std::size_t... Is>
 hstd::fmt_iter format_tuple_impl(
     Tuple const&         t,
     fmt::format_context& ctx,
@@ -15,12 +15,12 @@ hstd::fmt_iter format_tuple_impl(
       ::hstd::fmt_ctx((Is + 1 == sizeof...(Is) ? "" : ", "), ctx)));
     return ::hstd::fmt_ctx(")", ctx);
 }
-
 } // namespace hstd
 
-template <typename A, typename B>
-struct fmt::formatter<hstd::Pair<A, B>> : fmt::formatter<std::string> {
 
+template <typename A, typename B>
+struct fmt::formatter<hstd::Pair<A, B>> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(hstd::Pair<A, B> const& p, fmt::format_context& ctx) const {
         ::hstd::fmt_ctx("(", ctx);
         ::hstd::fmt_ctx(p.first, ctx);
@@ -31,8 +31,8 @@ struct fmt::formatter<hstd::Pair<A, B>> : fmt::formatter<std::string> {
 };
 
 template <typename... Args>
-struct fmt::formatter<std::tuple<Args...>> : fmt::formatter<std::string> {
-
+struct fmt::formatter<std::tuple<Args...>> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(std::tuple<Args...> const& t, fmt::format_context& ctx) const {
         return ::hstd::format_tuple_impl(t, ctx, std::index_sequence_for<Args...>{});
     }

--- a/src/hstd/stdlib/PtrsFormatter.hpp
+++ b/src/hstd/stdlib/PtrsFormatter.hpp
@@ -4,9 +4,9 @@
 
 
 template <typename T>
-struct std::formatter<hstd::SPtr<T>> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(hstd::SPtr<T> const& p, FormatContext& ctx) const {
+struct fmt::formatter<hstd::SPtr<T>> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(hstd::SPtr<T> const& p, fmt::format_context& ctx) const {
         if (p.get() == nullptr) {
             return ::hstd::fmt_ctx("nullptr", ctx);
         } else {
@@ -16,9 +16,9 @@ struct std::formatter<hstd::SPtr<T>> : std::formatter<std::string> {
 };
 
 template <typename T>
-struct std::formatter<hstd::UPtr<T>> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(hstd::UPtr<T> const& p, FormatContext& ctx) const {
+struct fmt::formatter<hstd::UPtr<T>> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(hstd::UPtr<T> const& p, fmt::format_context& ctx) const {
         if (p.get() == nullptr) {
             return ::hstd::fmt_ctx("nullptr", ctx);
         } else {

--- a/src/hstd/stdlib/PtrsFormatter.hpp
+++ b/src/hstd/stdlib/PtrsFormatter.hpp
@@ -4,8 +4,8 @@
 
 
 template <typename T>
-struct fmt::formatter<hstd::SPtr<T>> : fmt::formatter<std::string> {
-
+struct fmt::formatter<hstd::SPtr<T>> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(hstd::SPtr<T> const& p, fmt::format_context& ctx) const {
         if (p.get() == nullptr) {
             return ::hstd::fmt_ctx("nullptr", ctx);
@@ -16,8 +16,8 @@ struct fmt::formatter<hstd::SPtr<T>> : fmt::formatter<std::string> {
 };
 
 template <typename T>
-struct fmt::formatter<hstd::UPtr<T>> : fmt::formatter<std::string> {
-
+struct fmt::formatter<hstd::UPtr<T>> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(hstd::UPtr<T> const& p, fmt::format_context& ctx) const {
         if (p.get() == nullptr) {
             return ::hstd::fmt_ctx("nullptr", ctx);

--- a/src/hstd/stdlib/RangeTree.hpp
+++ b/src/hstd/stdlib/RangeTree.hpp
@@ -9,6 +9,7 @@
 #include <hstd/stdlib/Ptrs.hpp>
 #include <hstd/stdlib/Ranges.hpp>
 #include <hstd/stdlib/Formatter.hpp>
+#include <sstream>
 
 namespace hstd {
 
@@ -144,26 +145,27 @@ class RangeTree {
 } // namespace hstd
 
 template <typename T>
-struct std::formatter<hstd::RangeTreeRange<T>> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(hstd::RangeTreeRange<T> const& p, FormatContext& ctx) const {
+struct fmt::formatter<hstd::RangeTreeRange<T>> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+    hstd::fmt_iter format(hstd::RangeTreeRange<T> const& p, fmt::format_context& ctx)
+        const {
         ::hstd::fmt_ctx("[", ctx);
         ::hstd::fmt_ctx(p.range.first, ctx);
         ::hstd::fmt_ctx("..", ctx);
         ::hstd::fmt_ctx(p.range.last, ctx);
         ::hstd::fmt_ctx("[", ctx);
         ::hstd::fmt_ctx(p.index, ctx);
-        return fmt_ctx("]]", ctx);
+        return ::hstd::fmt_ctx("]]", ctx);
     }
 };
 
 
 template <typename T>
-struct std::formatter<hstd::RangeTree<T>> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(hstd::RangeTree<T> const& p, FormatContext& ctx) const {
+struct fmt::formatter<hstd::RangeTree<T>> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+    auto           format(hstd::RangeTree<T> const& p, fmt::format_context& ctx) const {
         if (p.root == nullptr) {
-            return fmt_ctx("nil", ctx);
+            return hstd::fmt_ctx("nil", ctx);
         } else {
             typename hstd::RangeTree<T>::Node& node = *(p.root.get());
             std::stringstream                  os;
@@ -172,7 +174,8 @@ struct std::formatter<hstd::RangeTree<T>> : std::formatter<std::string> {
             aux = [&](typename hstd::RangeTree<T>::Node const& node, int level) {
                 auto indent = hstd::Str("  ").repeated(level);
                 os << indent;
-                os << fmt("center = {} overlapping = {}", node.center, node.overlapping);
+                os << hstd::fmt(
+                    "center = {} overlapping = {}", node.center, node.overlapping);
 
                 if (node.left != nullptr) {
                     os << "\n" << indent << "  left = \n";
@@ -187,7 +190,7 @@ struct std::formatter<hstd::RangeTree<T>> : std::formatter<std::string> {
 
             aux(*p.root, 0);
 
-            return fmt_ctx(os.str(), ctx);
+            return hstd::fmt_ctx(os.str(), ctx);
         }
     }
 };

--- a/src/hstd/stdlib/SetFormatter.hpp
+++ b/src/hstd/stdlib/SetFormatter.hpp
@@ -4,13 +4,13 @@
 #include <hstd/stdlib/Formatter.hpp>
 
 template <typename T>
-struct std::formatter<hstd::UnorderedSet<T>>
+struct fmt::formatter<hstd::UnorderedSet<T>>
     : hstd::std_unordered_sequence_formatter<T, hstd::UnorderedSet<T>> {};
 
 template <typename T>
-struct std::formatter<std::unordered_set<T>>
+struct fmt::formatter<std::unordered_set<T>>
     : hstd::std_unordered_sequence_formatter<T, std::unordered_set<T>> {};
 
 template <typename T>
-struct std::formatter<std::set<T>>
+struct fmt::formatter<std::set<T>>
     : hstd::std_unordered_sequence_formatter<T, std::set<T>> {};

--- a/src/hstd/stdlib/Slice.hpp
+++ b/src/hstd/stdlib/Slice.hpp
@@ -186,10 +186,9 @@ HSlice<A, B> slice(A const& first, B const& last) {
 
 
 template <typename A, typename B>
-struct std::formatter<hstd::HSlice<A, B>> : std::formatter<std::string> {
-    template <typename FormatContext>
-    FormatContext::iterator format(hstd::HSlice<A, B> const& p, FormatContext& ctx)
-        const {
+struct fmt::formatter<hstd::HSlice<A, B>> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+    auto           format(hstd::HSlice<A, B> const& p, fmt::format_context& ctx) const {
         ::hstd::fmt_ctx("[", ctx);
         ::hstd::fmt_ctx(p.first, ctx);
         ::hstd::fmt_ctx("..", ctx);
@@ -199,9 +198,9 @@ struct std::formatter<hstd::HSlice<A, B>> : std::formatter<std::string> {
 };
 
 template <typename T>
-struct std::formatter<hstd::Slice<T>> : std::formatter<std::string> {
-    template <typename FormatContext>
-    FormatContext::iterator format(hstd::Slice<T> const& p, FormatContext& ctx) const {
+struct fmt::formatter<hstd::Slice<T>> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+    auto           format(hstd::Slice<T> const& p, fmt::format_context& ctx) const {
         ::hstd::fmt_ctx("[", ctx);
         ::hstd::fmt_ctx(p.first, ctx);
         ::hstd::fmt_ctx("..", ctx);
@@ -249,7 +248,7 @@ Pair<int, int> getSpan(
     if (checkRange
         && !((0 <= startPos && startPos < size) && (0 <= endPos && endPos < size))) {
         throw hstd::range_error::init(
-            std::format(
+            fmt::format(
                 "Container index is out of range: real span range is "
                 "{}..{} "
                 "computed from {}, but full extent length is only {}",

--- a/src/hstd/stdlib/SliceFormatter.hpp
+++ b/src/hstd/stdlib/SliceFormatter.hpp
@@ -5,9 +5,9 @@
 
 
 template <typename T>
-struct std::formatter<hstd::Span<T>> : std::formatter<std::string> {
-    template <typename FormatContext>
-    FormatContext::iterator format(hstd::Span<T> const& p, FormatContext& ctx) const {
+struct fmt::formatter<hstd::Span<T>> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(hstd::Span<T> const& p, fmt::format_context& ctx) const {
         hstd::fmt_ctx("[", ctx);
         for (int i = 0; i < p.size(); ++i) {
             if (0 < i) { hstd::fmt_ctx(", ", ctx); }

--- a/src/hstd/stdlib/SliceFormatter.hpp
+++ b/src/hstd/stdlib/SliceFormatter.hpp
@@ -5,8 +5,8 @@
 
 
 template <typename T>
-struct fmt::formatter<hstd::Span<T>> : fmt::formatter<std::string> {
-
+struct fmt::formatter<hstd::Span<T>> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(hstd::Span<T> const& p, fmt::format_context& ctx) const {
         hstd::fmt_ctx("[", ctx);
         for (int i = 0; i < p.size(); ++i) {

--- a/src/hstd/stdlib/Str.cpp
+++ b/src/hstd/stdlib/Str.cpp
@@ -1,5 +1,6 @@
 #include "Str.hpp"
 #include <hstd/stdlib/strutils.hpp>
+#include <sstream>
 
 using namespace hstd;
 

--- a/src/hstd/stdlib/Str.hpp
+++ b/src/hstd/stdlib/Str.hpp
@@ -5,7 +5,6 @@
 #include <hstd/stdlib/Span.hpp>
 #include <hstd/stdlib/Pair.hpp>
 #include <hstd/stdlib/Vec.hpp>
-#include <format>
 
 namespace hstd {
 
@@ -107,10 +106,10 @@ inline hstd::Str operator+(char const* in, hstd::Str const& other) {
 
 
 template <class CharT>
-struct std::formatter<hstd::Str, CharT> : std::formatter<std::string, CharT> {
-    template <typename FormatContext>
-    auto format(hstd::Str const& p, FormatContext& ctx) const {
-        return std::formatter<std::string, CharT>::format(p.toBase(), ctx);
+struct fmt::formatter<hstd::Str, CharT> : fmt::formatter<std::string, CharT> {
+
+    hstd::fmt_iter format(hstd::Str const& p, fmt::format_context& ctx) const {
+        return fmt::formatter<std::string, CharT>::format(p.toBase(), ctx);
     }
 };
 

--- a/src/hstd/stdlib/Time.cpp
+++ b/src/hstd/stdlib/Time.cpp
@@ -113,7 +113,7 @@ int64_t UserTime::toUnixTimestamp() const {
 
     if (seconds < unix_min || unix_max < seconds) {
         throw std::out_of_range(
-            std::format("Time {} is outside unix timestamp range", seconds));
+            fmt::format("Time {} is outside unix timestamp range", seconds));
     }
 
     return seconds;
@@ -134,19 +134,19 @@ std::size_t std::hash<UserTime>::operator()(UserTime const& it) const noexcept {
     return result;
 }
 
-template <typename FormatContext>
-FormatContext::iterator std::formatter<cctz::time_zone>::format(
+
+hstd::fmt_iter fmt::formatter<cctz::time_zone>::format(
     cctz::time_zone const& p,
-    FormatContext&         ctx) const {
+    fmt::format_context&   ctx) const {
     return fmt_ctx(p.name(), ctx);
 }
 
-template <typename FormatContext>
-FormatContext::iterator std::formatter<cctz::civil_second>::format(
+
+hstd::fmt_iter fmt::formatter<cctz::civil_second>::format(
     cctz::civil_second const& p,
-    FormatContext&            ctx) const {
+    fmt::format_context&      ctx) const {
     return hstd::fmt_ctx(
-        std::format(
+        fmt::format(
             "{:04}-{:02}-{:02} {:02}:{:02}:{:02}",
             p.year(),
             p.month(),
@@ -156,11 +156,3 @@ FormatContext::iterator std::formatter<cctz::civil_second>::format(
             p.second()),
         ctx);
 }
-
-template std::format_context::iterator std::formatter<cctz::civil_second>::format(
-    cctz::civil_second const&,
-    std::format_context&) const;
-
-template std::format_context::iterator std::formatter<cctz::time_zone, char>::format(
-    cctz::time_zone const&,
-    std::format_context&) const;

--- a/src/hstd/stdlib/Time.hpp
+++ b/src/hstd/stdlib/Time.hpp
@@ -66,13 +66,13 @@ struct std::hash<hstd::UserTime> {
 
 
 template <>
-struct std::formatter<cctz::civil_second> : std::formatter<std::string> {
-    template <typename FormatContext>
-    FormatContext::iterator format(cctz::civil_second const& p, FormatContext& ctx) const;
+struct fmt::formatter<cctz::civil_second> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+    hstd::fmt_iter format(cctz::civil_second const& p, fmt::format_context& ctx) const;
 };
 
 template <>
-struct std::formatter<cctz::time_zone> : std::formatter<std::string> {
-    template <typename FormatContext>
-    FormatContext::iterator format(cctz::time_zone const& p, FormatContext& ctx) const;
+struct fmt::formatter<cctz::time_zone> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+    hstd::fmt_iter format(cctz::time_zone const& p, fmt::format_context& ctx) const;
 };

--- a/src/hstd/stdlib/TraceBase.hpp
+++ b/src/hstd/stdlib/TraceBase.hpp
@@ -52,10 +52,11 @@ struct [[refl]] OperationsTracer {
 
     template <typename... _Args>
     [[nodiscard]] inline std::string fmt_message(
-        std::format_string<_Args...> __fmt,
+        fmt::format_string<_Args...> __fmt,
         _Args&&... __args) const {
         if (TraceState) {
-            return std::vformat(__fmt.get(), std::make_format_args(__args...));
+            auto store = fmt::make_format_args(__args...);
+            return fmt::vformat(__fmt.get(), fmt::format_args(store));
         } else {
             return "";
         }

--- a/src/hstd/stdlib/VariantFormatter.hpp
+++ b/src/hstd/stdlib/VariantFormatter.hpp
@@ -5,9 +5,9 @@
 
 
 template <hstd::DescribedSubVariantType V>
-struct std::formatter<V> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(V const& p, FormatContext& ctx) const {
+struct fmt::formatter<V> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(V const& p, fmt::format_context& ctx) const {
         ::hstd::fmt_ctx(p.sub_variant_get_kind(), ctx);
         ::hstd::fmt_ctx("(", ctx);
         std::visit(
@@ -28,9 +28,9 @@ struct std::formatter<V> : std::formatter<std::string> {
 
 
 template <hstd::IsVariant V>
-struct std::formatter<V> : std::formatter<std::string> {
-    template <typename FormatContext>
-    FormatContext::iterator format(V const& p, FormatContext& ctx) const {
+struct fmt::formatter<V> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(V const& p, fmt::format_context& ctx) const {
         std::string res;
         ::hstd::fmt_ctx("Var(", ctx);
         ::hstd::fmt_ctx(p.index(), ctx);

--- a/src/hstd/stdlib/VariantFormatter.hpp
+++ b/src/hstd/stdlib/VariantFormatter.hpp
@@ -5,8 +5,8 @@
 
 
 template <hstd::DescribedSubVariantType V>
-struct fmt::formatter<V> : fmt::formatter<std::string> {
-
+struct fmt::formatter<V> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(V const& p, fmt::format_context& ctx) const {
         ::hstd::fmt_ctx(p.sub_variant_get_kind(), ctx);
         ::hstd::fmt_ctx("(", ctx);
@@ -28,8 +28,8 @@ struct fmt::formatter<V> : fmt::formatter<std::string> {
 
 
 template <hstd::IsVariant V>
-struct fmt::formatter<V> : fmt::formatter<std::string> {
-
+struct fmt::formatter<V> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(V const& p, fmt::format_context& ctx) const {
         std::string res;
         ::hstd::fmt_ctx("Var(", ctx);

--- a/src/hstd/stdlib/VecFormatter.hpp
+++ b/src/hstd/stdlib/VecFormatter.hpp
@@ -15,3 +15,11 @@ struct fmt::formatter<std::vector<T>>
 template <typename T, int Size>
 struct fmt::formatter<hstd::SmallVec<T, Size>>
     : hstd::std_item_iterator_formatter<T, hstd::SmallVec<T, Size>> {};
+
+template <typename T>
+struct fmt::formatter<std::span<T>>
+    : hstd::std_item_iterator_formatter<T, std::span<T>> {};
+
+template <typename T>
+struct fmt::formatter<hstd::Span<T>>
+    : hstd::std_item_iterator_formatter<T, hstd::Span<T>> {};

--- a/src/hstd/stdlib/VecFormatter.hpp
+++ b/src/hstd/stdlib/VecFormatter.hpp
@@ -5,13 +5,13 @@
 
 /// \brief Vector formatting operator
 template <typename T>
-struct std::formatter<hstd::Vec<T>>
+struct fmt::formatter<hstd::Vec<T>>
     : hstd::std_item_iterator_formatter<T, hstd::Vec<T>> {};
 
 template <typename T>
-struct std::formatter<std::vector<T>>
+struct fmt::formatter<std::vector<T>>
     : hstd::std_item_iterator_formatter<T, std::vector<T>> {};
 
 template <typename T, int Size>
-struct std::formatter<hstd::SmallVec<T, Size>>
+struct fmt::formatter<hstd::SmallVec<T, Size>>
     : hstd::std_item_iterator_formatter<T, hstd::SmallVec<T, Size>> {};

--- a/src/hstd/stdlib/Yaml.hpp
+++ b/src/hstd/stdlib/Yaml.hpp
@@ -39,26 +39,26 @@ inline void maybe_enum_field(yaml const& in, E& out, std::string name, E fallbac
 
 
 template <>
-struct std::formatter<YAML::Mark> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(YAML::Mark const& p, FormatContext& ctx) const {
+struct fmt::formatter<YAML::Mark> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+    hstd::fmt_iter format(YAML::Mark const& p, fmt::format_context& ctx) const {
         if (p.is_null()) {
-            return fmt_ctx("null", ctx);
+            return hstd::fmt_ctx("null", ctx);
         } else {
-            fmt_ctx(p.pos, ctx);
-            fmt_ctx(":", ctx);
-            fmt_ctx(p.line, ctx);
-            fmt_ctx(":", ctx);
-            return fmt_ctx(p.column, ctx);
+            hstd::fmt_ctx(p.pos, ctx);
+            hstd::fmt_ctx(":", ctx);
+            hstd::fmt_ctx(p.line, ctx);
+            hstd::fmt_ctx(":", ctx);
+            return hstd::fmt_ctx(p.column, ctx);
         }
     }
 };
 
 template <>
-struct std::formatter<yaml> : std::formatter<std::string> {
-    template <typename FormatContext>
-    FormatContext::iterator format(yaml const& p, FormatContext& ctx) const {
-        std::formatter<std::string> fmt;
+struct fmt::formatter<yaml> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+    hstd::fmt_iter format(yaml const& p, fmt::format_context& ctx) const {
+        fmt::formatter<std::string> fmt;
         std::stringstream           os;
         os << p;
         return fmt.format(os.str(), ctx);

--- a/src/hstd/stdlib/Yaml.hpp
+++ b/src/hstd/stdlib/Yaml.hpp
@@ -58,10 +58,9 @@ template <>
 struct fmt::formatter<yaml> {
     constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(yaml const& p, fmt::format_context& ctx) const {
-        fmt::formatter<std::string> fmt;
-        std::stringstream           os;
+        std::stringstream os;
         os << p;
-        return fmt.format(os.str(), ctx);
+        return hstd::fmt_ctx(os.str(), ctx);
     }
 };
 

--- a/src/hstd/stdlib/diffs.cpp
+++ b/src/hstd/stdlib/diffs.cpp
@@ -2,6 +2,7 @@
 #include <hstd/stdlib/Debug.hpp>
 #include <hstd/stdlib/Ranges.hpp>
 #include <hstd/stdlib/Formatter.hpp>
+#include <hstd/stdlib/VecFormatter.hpp>
 
 #pragma clang diagnostic ignored "-Wreorder-init-list"
 
@@ -725,6 +726,7 @@ struct fuzzy_result {
     int  score;
 };
 
+// FIXME: Remove the special macro and use the regular OP_TRACER_MESSAGE macro here.
 #define LG(__msg)                                                                        \
     if (m.TraceState) {                                                                  \
         m.message(                                                                       \
@@ -747,7 +749,7 @@ fuzzy_result fuzzy_match_recursive(
     int&                recursionCount,
     int                 matchSize) {
 
-    LG(fmt("Match recursive count:{}", recursionCount));
+    LG(hstd::fmt("Match recursive count:{}", recursionCount));
 
     // Count recursions
     ++recursionCount;
@@ -770,11 +772,11 @@ fuzzy_result fuzzy_match_recursive(
     // Loop through pattern and str looking for a match
     bool first_match = true;
     while (pattern.isValid() && str.isValid()) {
-        LG(fmt("str:{} pattern:{}", str, pattern));
+        LG(hstd::fmt("str:{} pattern:{}", str, pattern));
         LOGIC_ASSERTION_CHECK(m.isEqual, "Missing item equality compare function");
         // Found match
         if (m.isEqual(pattern.first, str.first)) {
-            LG(fmt("pattern[{}] == str[{}]", pattern.first, str.first));
+            LG(hstd::fmt("pattern[{}] == str[{}]", pattern.first, str.first));
             // "Copy-on-Write" srcMatches into matches
             if (first_match) {
                 matches     = srcMatches;
@@ -797,10 +799,10 @@ fuzzy_result fuzzy_match_recursive(
                 recursionCount,
                 matchSize);
 
-            LG(
-                fmt("Recursive call result score:{} match:{}",
-                    recurse.score,
-                    recurse.has_match));
+            LG(hstd::fmt(
+                "Recursive call result score:{} match:{}",
+                recurse.score,
+                recurse.has_match));
 
             if (recurse.has_match) {
                 // Pick best recursive score
@@ -818,7 +820,7 @@ fuzzy_result fuzzy_match_recursive(
             ++pattern.first;
             LG(fmt1(matches));
         } else {
-            LG(fmt("pattern[{}] != str[{}]", pattern.first, str.first));
+            LG(hstd::fmt("pattern[{}] != str[{}]", pattern.first, str.first));
         }
         ++str.first;
     }

--- a/src/hstd/stdlib/diffs.hpp
+++ b/src/hstd/stdlib/diffs.hpp
@@ -9,6 +9,7 @@
 #include <hstd/stdlib/ColText.hpp>
 #include <hstd/stdlib/TraceBase.hpp>
 #include <math.h>
+#include <hstd/stdlib/ColTextFormatter.hpp>
 
 #include <hstd/system/reflection.hpp>
 
@@ -542,15 +543,15 @@ struct FormattedDiff {
                 int const idx = line.index().value();
                 if (formatLine) {
                     if (line.isLhs) {
-                        return std::format("[{:0{}}] {}", idx, digitCount, lhs->at(idx));
+                        return fmt::format("[{:0{}}] {}", idx, digitCount, lhs->at(idx));
                     } else {
-                        return std::format("[{:0{}}] {}", idx, digitCount, rhs->at(idx));
+                        return fmt::format("[{:0{}}] {}", idx, digitCount, rhs->at(idx));
                     }
                 } else {
                     if (line.isLhs) {
-                        return std::format("{}", lhs->at(idx));
+                        return fmt::format("{}", lhs->at(idx));
                     } else {
-                        return std::format("{}", rhs->at(idx));
+                        return fmt::format("{}", rhs->at(idx));
                     }
                 }
             }

--- a/src/hstd/stdlib/dod_base.hpp
+++ b/src/hstd/stdlib/dod_base.hpp
@@ -661,8 +661,8 @@ struct hash<Id> {
 
 template <typename Id>
     requires hstd::dod::IsIdType<Id> && hstd::DescribedRecord<Id>
-struct fmt::formatter<Id> : fmt::formatter<std::string> {
-
+struct fmt::formatter<Id> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(Id const& p, fmt::format_context& ctx) const {
         return hstd::fmt_ctx(p.format(), ctx);
     }

--- a/src/hstd/stdlib/dod_base.hpp
+++ b/src/hstd/stdlib/dod_base.hpp
@@ -661,9 +661,9 @@ struct hash<Id> {
 
 template <typename Id>
     requires hstd::dod::IsIdType<Id> && hstd::DescribedRecord<Id>
-struct std::formatter<Id> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(Id const& p, FormatContext& ctx) const {
+struct fmt::formatter<Id> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(Id const& p, fmt::format_context& ctx) const {
         return hstd::fmt_ctx(p.format(), ctx);
     }
 };

--- a/src/hstd/stdlib/dod_base_formatter.hpp
+++ b/src/hstd/stdlib/dod_base_formatter.hpp
@@ -5,11 +5,11 @@
 
 
 template <hstd::dod::IsDescribedDodIdType Id>
-struct std::formatter<Id> : std::formatter<std::string> {
+struct fmt::formatter<Id> : fmt::formatter<std::string> {
     using FmtType = Id;
-    template <typename FormatContext>
-    FormatContext::iterator format(FmtType const& p, FormatContext& ctx) const {
-        std::formatter<std::string> fmt;
+
+    hstd::fmt_iter format(FmtType const& p, fmt::format_context& ctx) const {
+        fmt::formatter<std::string> fmt;
         return fmt.format(p.format(), ctx);
     }
 };

--- a/src/hstd/stdlib/dod_base_formatter.hpp
+++ b/src/hstd/stdlib/dod_base_formatter.hpp
@@ -5,11 +5,9 @@
 
 
 template <hstd::dod::IsDescribedDodIdType Id>
-struct fmt::formatter<Id> : fmt::formatter<std::string> {
-    using FmtType = Id;
-
-    hstd::fmt_iter format(FmtType const& p, fmt::format_context& ctx) const {
-        fmt::formatter<std::string> fmt;
-        return fmt.format(p.format(), ctx);
+struct fmt::formatter<Id> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+    hstd::fmt_iter format(Id const& p, fmt::format_context& ctx) const {
+        return hstd::fmt_ctx(p.format(), ctx);
     }
 };

--- a/src/hstd/stdlib/reflection_visitor.hpp
+++ b/src/hstd/stdlib/reflection_visitor.hpp
@@ -18,8 +18,8 @@
 #include <typeindex>
 
 template <>
-struct fmt::formatter<std::any> : fmt::formatter<std::string> {
-
+struct fmt::formatter<std::any> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(std::any const& p, fmt::format_context& ctx) const {
         return ::hstd::fmt_ctx(p.type().name(), ctx);
     }
@@ -314,8 +314,8 @@ struct ReflPathItem {
 
 
 template <typename Tag>
-struct ReflPathItemFormatter : fmt::formatter<std::string> {
-
+struct ReflPathItemFormatter {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(ReflPathItem<Tag> const& step, fmt::format_context& ctx) const {
         typename ReflTypeTraits<Tag>::AnyFormatterType anyFmt;
         if (step.isAnyKey()) {
@@ -439,8 +439,8 @@ struct ReflPathComparator {
 };
 
 template <typename Tag>
-struct ReflPathFormatter : fmt::formatter<std::string> {
-
+struct ReflPathFormatter {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(ReflPath<Tag> const& step, fmt::format_context& ctx) const {
         ReflPathItemFormatter<Tag> fmt{};
         for (auto const& it : enumerator(step.path)) {
@@ -1006,8 +1006,8 @@ inline std::size_t get_registered_field_count(std::type_index type_id) {
 
 
 template <typename Tag>
-struct fmt::formatter<hstd::ReflPath<Tag>> : fmt::formatter<std::string> {
-
+struct fmt::formatter<hstd::ReflPath<Tag>> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(hstd::ReflPath<Tag> const& step, fmt::format_context& ctx)
         const {
         for (auto const& it : enumerator(step.path)) {
@@ -1029,8 +1029,8 @@ struct std::hash<hstd::ReflPath<Tag>> {
 };
 
 template <typename Tag>
-struct fmt::formatter<hstd::ReflPathItem<Tag>> : fmt::formatter<std::string> {
-
+struct fmt::formatter<hstd::ReflPathItem<Tag>> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(hstd::ReflPathItem<Tag> const& step, fmt::format_context& ctx)
         const {
         step.visit([&](auto const& it) { ::hstd::fmt_ctx(it, ctx); });

--- a/src/hstd/stdlib/reflection_visitor.hpp
+++ b/src/hstd/stdlib/reflection_visitor.hpp
@@ -15,11 +15,12 @@
 #include <hstd/stdlib/algorithms.hpp>
 #include <boost/preprocessor.hpp>
 #include <hstd/stdlib/Formatter.hpp>
+#include <typeindex>
 
 template <>
-struct std::formatter<std::any> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(std::any const& p, FormatContext& ctx) const {
+struct fmt::formatter<std::any> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(std::any const& p, fmt::format_context& ctx) const {
         return ::hstd::fmt_ctx(p.type().name(), ctx);
     }
 };
@@ -313,9 +314,9 @@ struct ReflPathItem {
 
 
 template <typename Tag>
-struct ReflPathItemFormatter : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(ReflPathItem<Tag> const& step, FormatContext& ctx) const {
+struct ReflPathItemFormatter : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(ReflPathItem<Tag> const& step, fmt::format_context& ctx) const {
         typename ReflTypeTraits<Tag>::AnyFormatterType anyFmt;
         if (step.isAnyKey()) {
             fmt_ctx(anyFmt(step.getAnyKey().key), ctx);
@@ -438,9 +439,9 @@ struct ReflPathComparator {
 };
 
 template <typename Tag>
-struct ReflPathFormatter : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(ReflPath<Tag> const& step, FormatContext& ctx) const {
+struct ReflPathFormatter : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(ReflPath<Tag> const& step, fmt::format_context& ctx) const {
         ReflPathItemFormatter<Tag> fmt{};
         for (auto const& it : enumerator(step.path)) {
             if (!it.is_first()) { fmt_ctx(">>", ctx); }
@@ -1005,9 +1006,10 @@ inline std::size_t get_registered_field_count(std::type_index type_id) {
 
 
 template <typename Tag>
-struct std::formatter<hstd::ReflPath<Tag>> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(hstd::ReflPath<Tag> const& step, FormatContext& ctx) const {
+struct fmt::formatter<hstd::ReflPath<Tag>> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(hstd::ReflPath<Tag> const& step, fmt::format_context& ctx)
+        const {
         for (auto const& it : enumerator(step.path)) {
             if (!it.is_first()) { ::hstd::fmt_ctx(">>", ctx); }
             ::hstd::fmt_ctx(it.value(), ctx);
@@ -1027,9 +1029,10 @@ struct std::hash<hstd::ReflPath<Tag>> {
 };
 
 template <typename Tag>
-struct std::formatter<hstd::ReflPathItem<Tag>> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(hstd::ReflPathItem<Tag> const& step, FormatContext& ctx) const {
+struct fmt::formatter<hstd::ReflPathItem<Tag>> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(hstd::ReflPathItem<Tag> const& step, fmt::format_context& ctx)
+        const {
         step.visit([&](auto const& it) { ::hstd::fmt_ctx(it, ctx); });
         return ::hstd::fmt_ctx("", ctx);
     }

--- a/src/hstd/stdlib/strutils.cpp
+++ b/src/hstd/stdlib/strutils.cpp
@@ -1,5 +1,6 @@
 #include <hstd/stdlib/strutils.hpp>
 #include <numeric>
+#include <sstream>
 
 using namespace hstd;
 
@@ -1351,11 +1352,11 @@ std::string hstd::format_number(double value) {
     double int_part  = 0.0;
     double frac_part = std::modf(abs_value, &int_part);
 
-    if (frac_part == 0.0) { return std::format("{}", value); }
+    if (frac_part == 0.0) { return fmt::format("{}", value); }
 
     if (int_part != 0.0) {
         double      scaled = std::trunc(value * 1000.0) / 1000.0;
-        std::string s      = std::format("{:.3f}", scaled);
+        std::string s      = fmt::format("{:.3f}", scaled);
 
         while (!s.empty() && s.back() == '0') { s.pop_back(); }
         if (!s.empty() && s.back() == '.') { s.pop_back(); }
@@ -1365,7 +1366,7 @@ std::string hstd::format_number(double value) {
 
     int         exponent = static_cast<int>(std::floor(std::log10(abs_value)));
     int         decimals = std::clamp(-exponent + 2, 0, 9);
-    std::string s        = std::format("{:.{}f}", value, decimals);
+    std::string s        = fmt::format("{:.{}f}", value, decimals);
 
     while (!s.empty() && s.back() == '0') { s.pop_back(); }
     if (!s.empty() && s.back() == '.') { s.pop_back(); }
@@ -1408,28 +1409,28 @@ void hstd::validate_utf8(std::string const& str) {
             // 2-byte sequence
             if (len <= i + 1) {
                 throw logic_assertion_error::init(
-                    std::format("Incomplete 2-byte UTF-8 sequence at position {}", i));
+                    fmt::format("Incomplete 2-byte UTF-8 sequence at position {}", i));
             }
             if ((bytes[i + 1] & 0xC0) != 0x80) {
                 throw logic_assertion_error::init(
-                    std::format("Invalid 2-byte UTF-8 sequence at position {}", i));
+                    fmt::format("Invalid 2-byte UTF-8 sequence at position {}", i));
             }
             i += 1;
         } else if (0xE0 <= bytes[i] && bytes[i] <= 0xEF) {
             // 3-byte sequence
             if (len <= i + 2) {
                 throw logic_assertion_error::init(
-                    std::format("Incomplete 3-byte UTF-8 sequence at position {}", i));
+                    fmt::format("Incomplete 3-byte UTF-8 sequence at position {}", i));
             }
             if ((bytes[i + 1] & 0xC0) != 0x80 || (bytes[i + 2] & 0xC0) != 0x80) {
                 throw logic_assertion_error::init(
-                    std::format("Invalid 3-byte UTF-8 sequence at position {}", i));
+                    fmt::format("Invalid 3-byte UTF-8 sequence at position {}", i));
             }
 
             // Special case for UTF-8 surrogate values
             if (bytes[i] == 0xE0 && (bytes[i + 1] < 0xA0)) {
                 throw logic_assertion_error::init(
-                    std::format(
+                    fmt::format(
                         "Invalid 3-byte UTF-8 sequence (overlong "
                         "encoding) at "
                         "position {}",
@@ -1437,7 +1438,7 @@ void hstd::validate_utf8(std::string const& str) {
             }
             if (bytes[i] == 0xED && (bytes[i + 1] > 0x9F)) {
                 throw logic_assertion_error::init(
-                    std::format(
+                    fmt::format(
                         "Invalid 3-byte UTF-8 sequence (surrogate pair) "
                         "at "
                         "position {}",
@@ -1449,18 +1450,18 @@ void hstd::validate_utf8(std::string const& str) {
             // 4-byte sequence
             if (len <= i + 3) {
                 throw logic_assertion_error::init(
-                    std::format("Incomplete 4-byte UTF-8 sequence at position {}", i));
+                    fmt::format("Incomplete 4-byte UTF-8 sequence at position {}", i));
             }
             if ((bytes[i + 1] & 0xC0) != 0x80 || (bytes[i + 2] & 0xC0) != 0x80
                 || (bytes[i + 3] & 0xC0) != 0x80) {
                 throw logic_assertion_error::init(
-                    std::format("Invalid 4-byte UTF-8 sequence at position {}", i));
+                    fmt::format("Invalid 4-byte UTF-8 sequence at position {}", i));
             }
 
             // Check for valid range
             if (bytes[i] == 0xF0 && (bytes[i + 1] < 0x90)) {
                 throw logic_assertion_error::init(
-                    std::format(
+                    fmt::format(
                         "Invalid 4-byte UTF-8 sequence (overlong "
                         "encoding) at "
                         "position {}",
@@ -1468,7 +1469,7 @@ void hstd::validate_utf8(std::string const& str) {
             }
             if (bytes[i] == 0xF4 && (bytes[i + 1] > 0x8F)) {
                 throw logic_assertion_error::init(
-                    std::format(
+                    fmt::format(
                         "Invalid 4-byte UTF-8 sequence (out of Unicode "
                         "range) "
                         "at position {}",
@@ -1478,7 +1479,7 @@ void hstd::validate_utf8(std::string const& str) {
             i += 3;
         } else {
             throw logic_assertion_error::init(
-                std::format(
+                fmt::format(
                     "Invalid UTF-8 leading byte 0x{:02X} at position {}", bytes[i], i));
         }
     }

--- a/src/hstd/stdlib/strutils.hpp
+++ b/src/hstd/stdlib/strutils.hpp
@@ -13,7 +13,7 @@ Str join(Str const& sep, generator<T>& list) {
     int index = 0;
     for (const auto& it : list) {
         if (0 < index) { os += sep; }
-        os += std::format("{}", it);
+        os += fmt::format("{}", it);
         ++index;
     }
     return os;

--- a/src/hstd/system/reflection.hpp
+++ b/src/hstd/system/reflection.hpp
@@ -563,7 +563,7 @@ struct fmt::formatter<T> {
     using FmtType = T;
     constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     auto           format(FmtType const& p, fmt::format_context& ctx) const {
-        return fmt::format_to(ctx.out(), std::to_string((int)p), ctx);
+        return fmt::format_to(ctx.out(), "{}", std::to_string((int)p));
     }
 };
 

--- a/src/hstd/system/reflection.hpp
+++ b/src/hstd/system/reflection.hpp
@@ -1,18 +1,15 @@
 #pragma once
 
-#include <iostream>
 #include <string>
-#include <sstream>
 #include <optional>
 
 #include <boost/mp11.hpp>
 #include <boost/describe.hpp>
 #include <hstd/system/basic_typedefs.hpp>
 #include <hstd/system/basic_templates.hpp>
-#include <typeindex>
 #include <vector>
-#include <format>
 #include <type_traits>
+#include <fmt/base.h>
 
 
 namespace hstd {
@@ -552,23 +549,21 @@ int get_total_field_index_by_ptr(F T::* fieldPtr) {
 } // namespace hstd
 
 template <hstd::SerializableEnum T>
-struct std::formatter<T> : std::formatter<std::string> {
+struct fmt::formatter<T> {
     using FmtType = T;
-    template <typename FormatContext>
-    FormatContext::iterator format(FmtType const& p, FormatContext& ctx) const {
-        std::formatter<std::string> fmt;
-        return fmt.format(hstd::enum_serde<T>::to_string(p), ctx);
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+    auto           format(FmtType const& p, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", hstd::enum_serde<T>::to_string(p));
     }
 };
 
 
 template <hstd::NonSerializableEnum T>
-struct std::formatter<T> : std::formatter<std::string> {
+struct fmt::formatter<T> {
     using FmtType = T;
-    template <typename FormatContext>
-    FormatContext::iterator format(FmtType const& p, FormatContext& ctx) const {
-        std::formatter<std::string> fmt;
-        return fmt.format(std::to_string((int)p), ctx);
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+    auto           format(FmtType const& p, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), std::to_string((int)p), ctx);
     }
 };
 

--- a/src/hstd/system/string_base.cpp
+++ b/src/hstd/system/string_base.cpp
@@ -1,9 +1,9 @@
 #include <hstd/system/string_base.hpp>
-#include <format>
+#include <fmt/format.h>
 
 template <std::integral T>
 std::string format_string_to_hex(T const& value) {
-    return std::format("{:0{}X}", value, sizeof(T) * 2);
+    return fmt::format("{:0{}X}", value, sizeof(T) * 2);
 }
 
 template std::string format_string_to_hex<int>(int const& value);
@@ -22,7 +22,7 @@ template std::string format_string_to_hex<unsigned short int>(
 
 template <std::integral T>
 std::string format_string_to_bin(T const& value) {
-    return std::format("{:0{}b}", value, sizeof(T) * 8);
+    return fmt::format("{:0{}b}", value, sizeof(T) * 8);
 }
 
 template std::string format_string_to_bin<int>(int const& value);

--- a/src/hstd/system/string_convert.hpp
+++ b/src/hstd/system/string_convert.hpp
@@ -2,7 +2,6 @@
 
 #include <iostream>
 #include <string>
-#include <format>
 #include <boost/mp11.hpp>
 #include <boost/describe.hpp>
 
@@ -15,7 +14,7 @@ std::string join(std::string const& sep, Iterable const& list) {
     int         index = 0;
     for (const auto& it : list) {
         if (0 < index) { os += sep; }
-        os += std::format("{}", it);
+        os += fmt::format("{}", it);
         ++index;
     }
     return os;
@@ -30,8 +29,8 @@ inline std::ostream& operator<<(std::ostream& os, std::ostream const&) { return 
 #define __xxloc() std::cout << __FILE__ << ":" << __LINE__ << "\n";
 
 template <typename T>
-concept StdFormattable = requires(T& v, std::format_context ctx) {
-    std::formatter<std::remove_cvref_t<T>>().format(v, ctx);
+concept StdFormattable = requires(T& v, fmt::format_context ctx) {
+    fmt::formatter<std::remove_cvref_t<T>>().format(v, ctx);
 };
 
 } // namespace hstd

--- a/src/py_libs/nanobind_utils.hpp
+++ b/src/py_libs/nanobind_utils.hpp
@@ -347,7 +347,7 @@ void init_fields_from_kwargs(R& value, nb::kwargs const& kwargs) {
             passed_kwargs.incl(hstd::Str(nb::str(it.first).c_str()));
         }
         throw std::logic_error(
-            fmt("Passed unknown field name {}", (passed_kwargs - used_kwargs)));
+            hstd::fmt("Passed unknown field name {}", (passed_kwargs - used_kwargs)));
     }
 }
 

--- a/src/py_libs/pyhaxorg/pyhaxorg_manual_impl.cpp
+++ b/src/py_libs/pyhaxorg/pyhaxorg_manual_impl.cpp
@@ -54,7 +54,7 @@ std::string format_function_definition(nanobind::callable const& func) {
     auto file = std::string{nanobind::str(obj.attr("co_filename")).c_str()};
     auto line = nanobind::cast<int>(obj.attr("co_firstlineno"));
 
-    return std::format(
+    return fmt::format(
         "{}:{}@{}", name, line, std::filesystem::path(file).stem().string());
 }
 
@@ -65,7 +65,7 @@ std::string ExporterPython::describe(PyFunc const& func) const {
 
 std::string ExporterPython::describe_use(std::string const& msg, PyFunc const& usage)
     const {
-    return std::format("{} {}", msg, describe(usage));
+    return fmt::format("{} {}", msg, describe(usage));
 }
 
 void ExporterPython::enableBufferTrace() {

--- a/src/py_libs/pyhaxorg/pyhaxorg_manual_impl.hpp
+++ b/src/py_libs/pyhaxorg/pyhaxorg_manual_impl.hpp
@@ -59,8 +59,8 @@
 
 
 template <>
-struct fmt::formatter<nanobind::callable> : fmt::formatter<std::string> {
-
+struct fmt::formatter<nanobind::callable> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(nanobind::callable const& p, fmt::format_context& ctx) const {
         return hstd::fmt_ctx("nanobind::callable", ctx);
     }
@@ -403,7 +403,7 @@ struct [[refl(R"({"backend": {"target-backends": ["python"]}})")]] ExporterPytho
         } else {
             trace_instant(trace(VK::NewRes)
                               .with_node(node)
-                              .with_msg(fmt("no callback for {}", T::staticKind)));
+                              .with_msg(hstd::fmt("no callback for {}", T::staticKind)));
             return nanobind::none();
         }
     }

--- a/src/py_libs/pyhaxorg/pyhaxorg_manual_impl.hpp
+++ b/src/py_libs/pyhaxorg/pyhaxorg_manual_impl.hpp
@@ -59,9 +59,9 @@
 
 
 template <>
-struct std::formatter<nanobind::callable> : std::formatter<std::string> {
-    template <typename FormatContext>
-    auto format(nanobind::callable const& p, FormatContext& ctx) const {
+struct fmt::formatter<nanobind::callable> : fmt::formatter<std::string> {
+
+    hstd::fmt_iter format(nanobind::callable const& p, fmt::format_context& ctx) const {
         return hstd::fmt_ctx("nanobind::callable", ctx);
     }
 };

--- a/test_formatter_debug.cpp
+++ b/test_formatter_debug.cpp
@@ -1,6 +1,5 @@
 #include <hstd/stdlib/Vec.hpp>
 #include <hstd/stdlib/VecFormatter.hpp>
-#include <format>
 #include <iostream>
 
 int main() {
@@ -9,8 +8,8 @@ int main() {
     Vec<std::string>          v{"first", "second"};
     SmallVec<std::string, 10> sv{"first", "second"};
 
-    std::string v_fmt  = std::format("{}", v);
-    std::string sv_fmt = std::format("{}", sv);
+    std::string v_fmt  = fmt::format("{}", v);
+    std::string sv_fmt = fmt::format("{}", sv);
 
     std::cout << "Vec format:      '" << v_fmt << "'\n";
     std::cout << "SmallVec format: '" << sv_fmt << "'\n";

--- a/tests/common.hpp
+++ b/tests/common.hpp
@@ -21,7 +21,7 @@ extern TestParameters testParameters;
 // you can possible have. The shit doesn't work reliably, you need to do
 // some fucking magic with namespaces and whatever the fuck else, it does
 // not work again, and with functions you need to specify the concrete type
-// for every type. If this was a structure I could've used `std::format`
+// for every type. If this was a structure I could've used `fmt::format`
 // with some form of concept here, if the library was actually written with
 // this in mind.
 //

--- a/tests/hstd/tASTDiff.cpp
+++ b/tests/hstd/tASTDiff.cpp
@@ -51,7 +51,7 @@ struct TestNodeStore : NodeStore {
 
     Func<ColText(NodeStore::Id const&)> getToStr() {
         return [](NodeStore::Id const& arg) -> ColText {
-            return std::format("{}", arg.ToPtr<TestNode>()->value);
+            return fmt::format("{}", arg.ToPtr<TestNode>()->value);
         };
     }
 };

--- a/tests/hstd/tDiff.cpp
+++ b/tests/hstd/tDiff.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <hstd/stdlib/diffs.hpp>
+#include <hstd/stdlib/VecFormatter.hpp>
 #include "hstd_tests_common.hpp"
 
 using namespace hstd;

--- a/tests/hstd/tDynVariant.cpp
+++ b/tests/hstd/tDynVariant.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include <string>
 #include <hstd/stdlib/DynVariant.hpp>
+#include <fmt/format.h>
 
 struct Shape {
     enum struct Kind
@@ -198,11 +199,11 @@ TEST_F(DynVariantTest, VisitWithTypeSpecificLogic) {
     std::string result = hstd::dyn_visit(
         []<typename T>(std::shared_ptr<T> const& shape) -> std::string {
             if constexpr (std::is_same_v<T, Circle>) {
-                return std::format("Circle with radius {}", shape->radius);
+                return fmt::format("Circle with radius {}", shape->radius);
             } else if constexpr (std::is_same_v<T, Rectangle>) {
-                return std::format("Rectangle {}x{}", shape->width, shape->height);
+                return fmt::format("Rectangle {}x{}", shape->width, shape->height);
             } else {
-                return std::format(
+                return fmt::format(
                     "Triangle base {} height {}", shape->base, shape->height);
             }
         },
@@ -391,12 +392,12 @@ TEST(DynVariantNestedInParent, VectorOfParents) {
         std::string desc = hstd::dyn_visit(
             [&parent]<typename T>(std::shared_ptr<T> const& s) -> std::string {
                 if constexpr (std::is_same_v<T, Parent::Circle>) {
-                    return std::format("{}: Circle(r={})", parent.name, s->radius);
+                    return fmt::format("{}: Circle(r={})", parent.name, s->radius);
                 } else if constexpr (std::is_same_v<T, Parent::Rectangle>) {
-                    return std::format(
+                    return fmt::format(
                         "{}: Rect({}x{})", parent.name, s->width, s->height);
                 } else {
-                    return std::format(
+                    return fmt::format(
                         "{}: Tri(b={},h={})", parent.name, s->base, s->height);
                 }
             },
@@ -642,9 +643,9 @@ TEST(DynVariantManyTypes, VisitWithTypeSpecificBehavior) {
     std::string result = hstd::dyn_visit(
         []<typename T>(std::shared_ptr<T> const& n) -> std::string {
             if constexpr (std::is_same_v<T, Type15>) {
-                return std::format("Type15: {}", n->value);
+                return fmt::format("Type15: {}", n->value);
             } else {
-                return std::format("Other: {}", n->value);
+                return fmt::format("Other: {}", n->value);
             }
         },
         v);

--- a/tests/hstd/tIntSet.cpp
+++ b/tests/hstd/tIntSet.cpp
@@ -125,7 +125,7 @@ TEST(TestIntegralSetOperations, ValueDomainSanityChecks) {
     for (unsigned char uc = 0;; ++uc) {
         char c = static_cast<char>(uc);
         EXPECT_EQ(D::ord(c), count)
-            << std::format("'{}' ({:B} {:B}) != '{}'", c, c, uc, count);
+            << fmt::format("'{}' ({:B} {:B}) != '{}'", c, c, uc, count);
         ++count;
         if (uc == 255) { break; }
     }

--- a/tests/hstd/tKiwiIR.cpp
+++ b/tests/hstd/tKiwiIR.cpp
@@ -8,8 +8,8 @@ namespace hstd::ext::kiwi_ir {
 static void write_outputs(Layout& layout, Opt<Str> name_r = std::nullopt) {
     auto name = name_r.value_or(std::string{getDebugFile().filename().c_str()});
     writeFile(
-        getDebugFile(std::format("{}.svg", name)), layout.to_svg(name).to_string(2));
-    layout.to_graphviz(getDebugFile(std::format("{}-graph.png", name)));
+        getDebugFile(fmt::format("{}.svg", name)), layout.to_svg(name).to_string(2));
+    layout.to_graphviz(getDebugFile(fmt::format("{}-graph.png", name)));
 }
 
 TEST(KiwiIr, AlignAndSeparate) {

--- a/tests/hstd/tLogger.cpp
+++ b/tests/hstd/tLogger.cpp
@@ -107,9 +107,9 @@ struct StdFormattableType {
 };
 
 template <>
-struct std::formatter<StdFormattableType> : std::formatter<std::string> {
-    auto format(StdFormattableType const& obj, format_context& ctx) const {
-        return std::formatter<std::string>::format(
+struct fmt::formatter<StdFormattableType> : fmt::formatter<std::string> {
+    hstd::fmt_iter format(StdFormattableType const& obj, format_context& ctx) const {
+        return fmt::formatter<std::string>::format(
             "std_fmt:" + std::to_string(obj.value), ctx);
     }
 };
@@ -132,9 +132,9 @@ struct BothFormattableType {
 };
 
 template <>
-struct std::formatter<BothFormattableType> : std::formatter<std::string> {
-    auto format(BothFormattableType const& obj, format_context& ctx) const {
-        return std::formatter<std::string>::format(
+struct fmt::formatter<BothFormattableType> : fmt::formatter<std::string> {
+    hstd::fmt_iter format(BothFormattableType const& obj, format_context& ctx) const {
+        return fmt::formatter<std::string>::format(
             "std_both:" + std::to_string(obj.value), ctx);
     }
 };

--- a/tests/hstd/tLogger.cpp
+++ b/tests/hstd/tLogger.cpp
@@ -12,6 +12,7 @@
 #include "../common.hpp"
 
 #include <hstd/stdlib/OptFormatter.hpp>
+#include <hstd/stdlib/PairFormatter.hpp>
 
 #if ORG_BUILD_WITH_QT
 #    include <QString>
@@ -107,10 +108,10 @@ struct StdFormattableType {
 };
 
 template <>
-struct fmt::formatter<StdFormattableType> : fmt::formatter<std::string> {
+struct fmt::formatter<StdFormattableType> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(StdFormattableType const& obj, format_context& ctx) const {
-        return fmt::formatter<std::string>::format(
-            "std_fmt:" + std::to_string(obj.value), ctx);
+        return hstd::fmt_ctx("std_fmt:" + std::to_string(obj.value), ctx);
     }
 };
 
@@ -133,9 +134,9 @@ struct BothFormattableType {
 
 template <>
 struct fmt::formatter<BothFormattableType> : fmt::formatter<std::string> {
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(BothFormattableType const& obj, format_context& ctx) const {
-        return fmt::formatter<std::string>::format(
-            "std_both:" + std::to_string(obj.value), ctx);
+        return hstd::fmt_ctx("std_both:" + std::to_string(obj.value), ctx);
     }
 };
 

--- a/tests/hstd/tLogger.cpp
+++ b/tests/hstd/tLogger.cpp
@@ -133,7 +133,7 @@ struct BothFormattableType {
 };
 
 template <>
-struct fmt::formatter<BothFormattableType> : fmt::formatter<std::string> {
+struct fmt::formatter<BothFormattableType> {
     constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     hstd::fmt_iter format(BothFormattableType const& obj, format_context& ctx) const {
         return hstd::fmt_ctx("std_both:" + std::to_string(obj.value), ctx);

--- a/tests/hstd/tLogger.cpp
+++ b/tests/hstd/tLogger.cpp
@@ -196,7 +196,7 @@ TEST_F(LoggerTest, StdFormatterSpecifications) {
 
     EXPECT_EQ(
         hstd::log::format_logger_arguments(
-            "Custom with spec: {:>15}", StdFormattableType{100}),
+            "Custom with spec: {:>15}", hstd::fmt1(StdFormattableType{100})),
         "Custom with spec:     std_fmt:100");
 }
 

--- a/tests/hstd/tReflection.cpp
+++ b/tests/hstd/tReflection.cpp
@@ -10,6 +10,7 @@
 #include <hstd/stdlib/VariantFormatter.hpp>
 #include <hstd/stdlib/PtrsFormatter.hpp>
 #include <hstd/stdlib/OptFormatter.hpp>
+#include <hstd/stdlib/SetFormatter.hpp>
 
 
 using namespace hstd;
@@ -1003,15 +1004,15 @@ TEST(ReflectionVisitor, PopulatedDataStructure) {
 
     for (const auto& [path, value] : expectedValues) {
         auto it = visitedValues.find(path);
-        EXPECT_NE(it, visitedValues.end()) << fmt("No path {}", path);
+        EXPECT_NE(it, visitedValues.end()) << hstd::fmt("No path {}", path);
         if (value) {
             EXPECT_EQ(it->second, value.value())
-                << fmt("{} -> {} != {}", path, it->second, value);
+                << hstd::fmt("{} -> {} != {}", path, it->second, value);
         }
     }
 
     for (const auto& [path, value] : visitedValues) {
         auto it = expectedValues.find(path);
-        EXPECT_NE(it, expectedValues.end()) << fmt("Unexpected path {}", path);
+        EXPECT_NE(it, expectedValues.end()) << hstd::fmt("Unexpected path {}", path);
     }
 }

--- a/tests/hstd/tReflection.cpp
+++ b/tests/hstd/tReflection.cpp
@@ -11,6 +11,9 @@
 #include <hstd/stdlib/PtrsFormatter.hpp>
 #include <hstd/stdlib/OptFormatter.hpp>
 #include <hstd/stdlib/SetFormatter.hpp>
+#include <hstd/stdlib/MapFormatter.hpp>
+#include <hstd/stdlib/VecFormatter.hpp>
+#include <hstd/stdlib/PairFormatter.hpp>
 
 
 using namespace hstd;

--- a/tests/hstd/tStr.cpp
+++ b/tests/hstd/tStr.cpp
@@ -3,6 +3,7 @@
 #include <hstd/stdlib/strutils.hpp>
 #include <hstd/stdlib/ColText.hpp>
 #include <hstd/stdlib/ColTextHShow.hpp>
+#include <hstd/stdlib/VecFormatter.hpp>
 
 #include "../common.hpp"
 

--- a/tests/hstd/tVec.cpp
+++ b/tests/hstd/tVec.cpp
@@ -16,14 +16,14 @@ using StrVecTestTypes = ::testing::Types<Vec<std::string>, SmallVec<std::string,
 TYPED_TEST_SUITE(StrVecTypedTest, StrVecTestTypes);
 
 TEST(BackwardsIndexTest, BackwardsIndexFormat) {
-    std::string f1 = std::format("{}", 1_B);
+    std::string f1 = fmt::format("{}", 1_B);
     ASSERT_EQ(f1, "^1");
 }
 
 TYPED_TEST(IntVecTypedTest, Formatter) {
-    EXPECT_EQ((std::format("{}", TypeParam{})), "[]");
-    EXPECT_EQ((std::format("{}", TypeParam{1})), "[1]");
-    EXPECT_EQ((std::format("{}", TypeParam{1, 2})), "[1, 2]");
+    EXPECT_EQ((fmt::format("{}", TypeParam{})), "[]");
+    EXPECT_EQ((fmt::format("{}", TypeParam{1})), "[1]");
+    EXPECT_EQ((fmt::format("{}", TypeParam{1, 2})), "[1, 2]");
 }
 
 TEST(VectorTest, ContainsFind) {

--- a/tests/org/tErrorFormat.cpp
+++ b/tests/org/tErrorFormat.cpp
@@ -147,7 +147,8 @@ struct PrintErrorTestSetup {
     void write_report(hstd::fs::path const& path) {
         writeFile(
             path,
-            fmt(R"(- - - - - -
+            hstd::fmt(
+                R"(- - - - - -
 {}
 - - - - - -
 {}
@@ -159,7 +160,7 @@ struct PrintErrorTestSetup {
                 own_view(rune_chunks(str)) //
                     | rv::enumerate
                     | rv::transform([](Pair<int, std::string> const& l) -> std::string {
-                          return fmt("[{}] {}", l.first, escape_literal(l.second));
+                          return hstd::fmt("[{}] {}", l.first, escape_literal(l.second));
                       })
                     | rv::intersperse("\n") //
                     | rv::join              //
@@ -231,8 +232,9 @@ TEST(PrintError, StringBuilder1) {
     Str pivoted     = pivotStringTable(report_text);
 
     writeFile(
-        getDebugFile(fmt("error_{}.txt", "StringBuilder1")),
-        fmt(R"(- - - - - -
+        getDebugFile(hstd::fmt("error_{}.txt", "StringBuilder1")),
+        hstd::fmt(
+            R"(- - - - - -
 {}
 - - - - - -
 {}
@@ -244,7 +246,7 @@ TEST(PrintError, StringBuilder1) {
             own_view(rune_chunks(str)) //
                 | rv::enumerate
                 | rv::transform([](Pair<int, std::string> const& l) -> std::string {
-                      return fmt("[{}] {}", l.first, escape_literal(l.second));
+                      return hstd::fmt("[{}] {}", l.first, escape_literal(l.second));
                   })
                 | rv::intersperse("\n") //
                 | rv::join              //
@@ -363,20 +365,22 @@ def six =
               .with_label(
                   Label{1}
                       .with_span(a_id, slice(30, 30))
-                      .with_message(fmt("This is of type {}", "Nat"))
+                      .with_message(hstd::fmt("This is of type {}", "Nat"))
                       .with_color(a))
               .with_label(
                   Label{2}
                       .with_span(a_id, slice(42, 45))
-                      .with_message(fmt("This is of type {}", "Str"))
+                      .with_message(hstd::fmt("This is of type {}", "Str"))
                       .with_color(b))
               .with_label(
                   Label{3}
                       .with_span(a_id, slice(11, 48))
                       .with_message(
-                          fmt("The values are outputs of this {} expression", "match")))
+                          hstd::fmt(
+                              "The values are outputs of this {} expression", "match")))
               .with_note(
-                  fmt("Outputs of {} expressions must coerce to the same type", "match"));
+                  hstd::fmt(
+                      "Outputs of {} expressions must coerce to the same type", "match"));
 
     dumpReport(sources, report);
     writeFile(getDebugFile("res.txt"), report.to_string(sources, false));
@@ -409,23 +413,26 @@ def six =
               .with_label(
                   Label{1}
                       .with_span(a_id, slice(30, 30))
-                      .with_message(fmt("Single line label on the base range", "Nat"))
+                      .with_message(
+                          hstd::fmt("Single line label on the base range", "Nat"))
                       .with_color(a))
               .with_label(
                   Label{2}
                       .with_span(a_id, slice(31, 31))
                       .with_message(
-                          fmt("Multiple line label\nwith at "
+                          hstd::fmt(
+                              "Multiple line label\nwith at "
                               "least\nthree separate lines"))
                       .with_color(b))
               .with_label(
                   Label{3}
                       .with_span(a_id, slice(32, 32))
                       .with_message(
-                          fmt("Another multiline\nannotation "
+                          hstd::fmt(
+                              "Another multiline\nannotation "
                               "immediately\nfollowing the previous\none"))
                       .with_color(b))
-              .with_note(fmt("Single line note"));
+              .with_note(hstd::fmt("Single line note"));
 
     dumpReport(sources, report);
     writeFile(getDebugFile("res.txt"), report.to_string(sources, false));
@@ -509,7 +516,7 @@ def multiline :: Str = match Some 5 in {
                      int         line     = __builtin_LINE(),
                      char const* function = __builtin_FUNCTION()) {
         return Label{++label_counter, CodeSpan(id, range)}.with_message(
-            fmt("MSG {} {}", range, line));
+            hstd::fmt("MSG {} {}", range, line));
     };
 
     auto report //
@@ -589,7 +596,7 @@ def multiline :: Str = match Some 5 in {
                      int         line     = __builtin_LINE(),
                      char const* function = __builtin_FUNCTION()) {
         return Label{++label_counter, CodeSpan(id, range)}.with_message(
-            fmt("MSG {} {}", range, line));
+            hstd::fmt("MSG {} {}", range, line));
     };
 
     auto report //
@@ -609,7 +616,8 @@ def multiline :: Str = match Some 5 in {
     dumpReport(sources, report);
     writeFile(
         getDebugFile("res.txt"),
-        fmt("{}\n{}..{}\n",
+        hstd::fmt(
+            "{}\n{}..{}\n",
             report.to_string(sources, false),
             code.at(108),
             code.at(122)));

--- a/tests/org/tImmMindMap.cpp
+++ b/tests/org/tImmMindMap.cpp
@@ -333,22 +333,22 @@ struct ImmMapApi : ImmOrgApiTestBase {
                    | hstd::rv::transform(std::bind_back(&testParseString, std::nullopt))
                    | hstd::rs::to<Vec>();
         for (auto const& [idx, node] : hstd::enumerate(nodes)) {
-            writeTreeRepr(node, getDebugFile(fmt("repr_{}.yaml", idx)));
+            writeTreeRepr(node, getDebugFile(hstd::fmt("repr_{}.yaml", idx)));
         }
 
         init_with(nodes);
         for (auto const& [idx, adapter] : hstd::enumerate(getRootAdapters())) {
-            writeTreeRepr(adapter, getDebugFile(fmt("repr_{}.txt", idx)));
+            writeTreeRepr(adapter, getDebugFile(hstd::fmt("repr_{}.txt", idx)));
             writeTreeRepr(
                 adapter,
-                getDebugFile(fmt("repr_{}_verbose.txt", idx)),
+                getDebugFile(hstd::fmt("repr_{}_verbose.txt", idx)),
                 imm::ImmAdapter::TreeReprConf{
                     .withReflFields = true,
                     .withAuxFields  = true,
                 });
 
             writeFile(
-                getDebugFile(fmt("repr_{}_tracking.txt", idx)),
+                getDebugFile(hstd::fmt("repr_{}_tracking.txt", idx)),
                 getVersion().getContext()->currentTrack->toString().toString(false));
         }
     }

--- a/tests/org/tOrgE2EParse.cpp
+++ b/tests/org/tOrgE2EParse.cpp
@@ -9,7 +9,7 @@ using namespace org::parse;
 using namespace org::test;
 
 Str getSelfTest(org::imm::ImmAdapter const& it) {
-    return fmt(
+    return hstd::fmt(
         R"(
 auto {0} = {1};
 EXPECT_EQ({0}->getKind(), OrgSemKind::{2});

--- a/tests/org/tOrgTestCommon.cpp
+++ b/tests/org/tOrgTestCommon.cpp
@@ -51,7 +51,7 @@ sem::SemId<sem::Org> testParseString(
 
         writeFile(
             fs::path{debug.value() + "_base_lexed.yaml"},
-            std::format("{}", org::test::yamlRepr(p.baseTokens)));
+            fmt::format("{}", org::test::yamlRepr(p.baseTokens)));
     } else {
         p.tokenizeBase(text, params, p.parseContext->addSource("<mock-full-run>", text));
     }
@@ -61,7 +61,7 @@ sem::SemId<sem::Org> testParseString(
     if (debug) {
         writeFile(
             fs::path{debug.value() + "_lexed.yaml"},
-            std::format("{}", org::test::yamlRepr(p.tokens)));
+            fmt::format("{}", org::test::yamlRepr(p.tokens)));
     }
 
     p.parse();
@@ -109,13 +109,13 @@ void show_compare_reports(Vec<compare_report> const& out) {
     for (auto const& it : out) {
         std::string ctx = it.context
                         | rv::transform([](compare_context const& c) -> std::string {
-                              return fmt("{}.{}", c.type, c.field);
+                              return hstd::fmt("{}.{}", c.type, c.field);
                           })
                         | rv::intersperse("->") //
                         | rv::join              //
                         | rs::to<std::string>();
 
-        buffer += fmt(
+        buffer += hstd::fmt(
             "{} failed: original != parsed\n{}\n", ctx, hstd::indent(it.message, 2));
     }
 

--- a/tests/org/tOrgTestCommon.hpp
+++ b/tests/org/tOrgTestCommon.hpp
@@ -67,15 +67,15 @@ struct compare_report {
 };
 
 template <typename T>
-    requires std::formattable<T, char>
+    requires fmt::formattable<T, char>
 std::string maybe_format(T const& value) {
-    return std::format("{}", value);
+    return fmt::format("{}", value);
 }
 
 template <typename T>
-    requires(!std::formattable<T, char>)
+    requires(!fmt::formattable<T, char>)
 std::string maybe_format(T const&) {
-    return fmt("<non-formattable {}>", demangle(typeid(T).name()));
+    return hstd::fmt("<non-formattable {}>", demangle(typeid(T).name()));
 }
 
 template <typename T>
@@ -87,7 +87,7 @@ void equality_compare_impl(
     if (!(lhs == rhs)) {
         out.push_back({
             .context = context,
-            .message = std::format(
+            .message = fmt::format(
                 "{} != {} on {} for {}",
                 escape_literal(maybe_format(lhs)),
                 escape_literal(maybe_format(rhs)),
@@ -150,7 +150,7 @@ struct reporting_comparator_key_value {
         for (auto const& lhs_only : lhs_keys - rhs_keys) {
             out.push_back({
                 .context = context,
-                .message = fmt(
+                .message = hstd::fmt(
                     "no key of type {} '{}' in lhs on {}",
                     value_metadata<K>::typeName(),
                     maybe_format(lhs_only),
@@ -161,7 +161,7 @@ struct reporting_comparator_key_value {
         for (auto const& rhs_only : rhs_keys - lhs_keys) {
             out.push_back({
                 .context = context,
-                .message = fmt(
+                .message = hstd::fmt(
                     "no key of type {} '{}' in rhs on {}",
                     value_metadata<K>::typeName(),
                     maybe_format(rhs_only),
@@ -181,7 +181,7 @@ struct reporting_comparator<std::optional<T>> {
         if (lhs.has_value() != rhs.has_value()) {
             out.push_back({
                 .context = context,
-                .message = fmt("on {}", __LINE__),
+                .message = hstd::fmt("on {}", __LINE__),
             });
         } else if (lhs.has_value()) {
             reporting_comparator<T>::compare(*lhs, *rhs, out, context);
@@ -238,7 +238,7 @@ struct reporting_comparator_indexed_sequence {
         if (lhs.size() != rhs.size()) {
             out.push_back({
                 .context = context,
-                .message = fmt(
+                .message = hstd::fmt(
                     "lhs.size() != rhs.size() ({} != {}) on {}",
                     lhs.size(),
                     rhs.size(),
@@ -252,7 +252,7 @@ struct reporting_comparator_indexed_sequence {
                     out,
                     context
                         + Vec<compare_context>{{
-                            .field = fmt("{}", i),
+                            .field = hstd::fmt("{}", i),
                             .type  = "Vec",
                         }});
             }
@@ -282,7 +282,7 @@ struct reporting_comparator<V> {
         if (lhs.index() != rhs.index()) {
             out.push_back({
                 .context = context,
-                .message = fmt(
+                .message = hstd::fmt(
                     "variant index differ {} != {} on {} for {}",
                     lhs.index(),
                     rhs.index(),
@@ -298,7 +298,7 @@ struct reporting_comparator<V> {
                         out,
                         context
                             + Vec<compare_context>{{
-                                .field = fmt("{}", lhs.index()),
+                                .field = hstd::fmt("{}", lhs.index()),
                                 .type  = "Variant",
                             }});
                 },
@@ -357,7 +357,7 @@ struct reporting_comparator<sem::SemId<T>> {
         if (lhs.isNil() != rhs.isNil()) {
             out.push_back({
                 .context = context,
-                .message = fmt(
+                .message = hstd::fmt(
                     "nil on {} -- lhs.isNil:{} rhs.isNil:{}",
                     __LINE__,
                     lhs.isNil(),
@@ -379,14 +379,15 @@ struct reporting_comparator<sem::SemId<sem::Org>> {
         if (lhs.isNil() != rhs.isNil()) {
             out.push_back({
                 .context = context,
-                .message = fmt("on {}", __LINE__),
+                .message = hstd::fmt("on {}", __LINE__),
             });
         } else if (lhs.isNil()) {
             // pass
         } else if (lhs->getKind() != rhs->getKind()) {
             out.push_back({
                 .context = context,
-                .message = fmt("kind mismatch {} != {}", lhs->getKind(), rhs->getKind()),
+                .message = hstd::fmt(
+                    "kind mismatch {} != {}", lhs->getKind(), rhs->getKind()),
             });
         } else {
             switch (lhs->getKind()) {
@@ -422,7 +423,7 @@ std::string dbgString(
     char const*          function = __builtin_FUNCTION(),
     int                  line     = __builtin_LINE(),
     char const*          file     = __builtin_FILE()) {
-    return fmt(
+    return hstd::fmt(
         "{}:{}\n{}",
         function,
         line,

--- a/tests/testprofiler.cpp
+++ b/tests/testprofiler.cpp
@@ -107,7 +107,7 @@ void TestProfiler::SetUp() {
             XRayLogRegisterStatus select = __xray_log_select_mode("xray-fdr");
             if (select != XRayLogRegisterStatus::XRAY_REGISTRATION_OK) {
                 throw std::logic_error(
-                    std::format(
+                    fmt::format(
                         "Failed to select xray-basic mode, the code was "
                         "'{}'",
                         (int)select));
@@ -117,7 +117,7 @@ void TestProfiler::SetUp() {
 
         {
             __perf_trace("cli", "Log init mode");
-            std::string options = std::format(
+            std::string options = fmt::format(
                 "buffer_size=16384:"
                 "buffer_max={}",
                 (1 << 16));
@@ -127,7 +127,7 @@ void TestProfiler::SetUp() {
 
             if (init_mode_status != XRayLogInitStatus::XRAY_LOG_INITIALIZED) {
                 throw std::logic_error(
-                    std::format(
+                    fmt::format(
                         "__xray_log_init_mode() failed, the code was '{}'",
                         (int)init_mode_status));
             }
@@ -141,7 +141,7 @@ void TestProfiler::SetUp() {
             auto patch_status = __xray_patch();
             if (patch_status != XRayPatchingStatus::SUCCESS) {
                 throw std::logic_error(
-                    std::format(
+                    fmt::format(
                         "__xray_patch() failed, the code was '{}'", (int)patch_status));
             }
         }
@@ -165,7 +165,7 @@ void TestProfiler::TearDown() {
         int profile_result = __llvm_profile_write_file();
         if (profile_result != 0) {
             throw std::logic_error(
-                std::format("Failed to write PGO data to '{}'", pgo_path.data()));
+                fmt::format("Failed to write PGO data to '{}'", pgo_path.data()));
         }
     }
 #endif
@@ -176,7 +176,7 @@ void TestProfiler::TearDown() {
         auto finalize_status = __xray_log_finalize();
         if (finalize_status != XRAY_LOG_FINALIZED) {
             throw std::logic_error(
-                std::format(
+                fmt::format(
                     "Failed to finalize XRAY Log, the status is, the code "
                     "was "
                     "'{}'",
@@ -189,7 +189,7 @@ void TestProfiler::TearDown() {
         auto flush_status = __xray_log_flushLog();
         if (flush_status != XRAY_LOG_FLUSHED) {
             throw std::logic_error(
-                std::format(
+                fmt::format(
                     "Failed to flush XRAY log, the status is "
                     "'{}'",
                     (int)flush_status));
@@ -201,7 +201,7 @@ void TestProfiler::TearDown() {
         XRayPatchingStatus status = __xray_unpatch();
         if (status != XRayPatchingStatus::SUCCESS) {
             throw std::logic_error(
-                std::format(
+                fmt::format(
                     "Failed to unpatch xray, the status is "
                     "'{}'",
                     (int)status));


### PR DESCRIPTION
faster compilation times, and an the format function itself does not
have to be a template, meaning I can move definition into the source
file.