### PR TITLE
feat(refl): collect information about include tree

### DIFF
--- a/scripts/cxx_codegen/branching_include_collector.hpp
+++ b/scripts/cxx_codegen/branching_include_collector.hpp
@@ -128,14 +128,41 @@ struct BranchingIncludeCollectorCallback : public clang::PPCallbacks {
     }
 
 
-    std::optional<PendingInclude> popPendingForParent(std::string const& parentPath) {
+    std::optional<PendingInclude> popPendingForParent(
+        std::string const& parentPath,
+        unsigned           includeLine,
+        std::string const& enteredPath) {
+
+        auto isParentMatch = [&](PendingInclude const& p) {
+            return p.IncludingFilePath == parentPath;
+        };
+
+        auto isStrongMatch = [&](PendingInclude const& p) {
+            if (!isParentMatch(p)) { return false; }
+            if (includeLine != 0 && p.PhysicalLine != includeLine) { return false; }
+            if (!enteredPath.empty() && !p.AbsolutePath.empty()
+                && p.AbsolutePath != enteredPath) {
+                return false;
+            }
+            return true;
+        };
+
         for (auto it = PendingIncludes.begin(); it != PendingIncludes.end(); ++it) {
-            if (it->IncludingFilePath == parentPath) {
+            if (isStrongMatch(*it)) {
                 PendingInclude result = *it;
                 PendingIncludes.erase(it);
                 return result;
             }
         }
+
+        for (auto it = PendingIncludes.begin(); it != PendingIncludes.end(); ++it) {
+            if (isParentMatch(*it)) {
+                PendingInclude result = *it;
+                PendingIncludes.erase(it);
+                return result;
+            }
+        }
+
         return std::nullopt;
     }
 
@@ -157,7 +184,10 @@ struct BranchingIncludeCollectorCallback : public clang::PPCallbacks {
         std::string enteredPath = getRealPathForLoc(*SM, spelling);
         std::string parentPath  = ActiveStack.back().AbsolutePath;
 
-        auto pending = popPendingForParent(parentPath);
+        unsigned includeLine = 0;
+        if (spelling.isValid()) { includeLine = SM->getSpellingLineNumber(spelling); }
+
+        auto pending = popPendingForParent(parentPath, includeLine, enteredPath);
 
         IncludeVisit* nested = ActiveStack.back().Node->add_nested();
         nested->set_absolutepath(enteredPath);

--- a/scripts/cxx_codegen/branching_include_collector.hpp
+++ b/scripts/cxx_codegen/branching_include_collector.hpp
@@ -10,6 +10,7 @@
 
 #include "reflection_config.hpp"
 #include "reflection_defs.pb.h"
+#include <filesystem>
 
 
 struct BranchingIncludeCollectorCallback : public clang::PPCallbacks {
@@ -19,14 +20,25 @@ struct BranchingIncludeCollectorCallback : public clang::PPCallbacks {
 
     IncludeVisit* Root = nullptr;
 
+    static std::string normalizeAbsolutePath(std::string const& rawPath) {
+        if (rawPath.empty()) { return {}; }
+
+        std::filesystem::path p(rawPath);
+        if (p.is_relative()) { p = std::filesystem::absolute(p); }
+
+        p = p.lexically_normal();
+        return p.string();
+    }
+
     static std::string getMainFileAbsolutePath(clang::CompilerInstance& CI) {
         clang::SourceManager&       SM     = CI.getSourceManager();
         clang::FileID               mainId = SM.getMainFileID();
         clang::OptionalFileEntryRef file   = SM.getFileEntryRefForID(mainId);
         if (file) {
-            return file->getName().str();
+            return normalizeAbsolutePath(file->getName().str());
         } else {
-            return SM.getFileEntryRefForID(mainId)->getName().str();
+            return normalizeAbsolutePath(
+                SM.getFileEntryRefForID(mainId)->getName().str());
         }
     }
 
@@ -38,10 +50,10 @@ struct BranchingIncludeCollectorCallback : public clang::PPCallbacks {
 
         clang::FileID               fid  = SM.getFileID(spelling);
         clang::OptionalFileEntryRef file = SM.getFileEntryRefForID(fid);
-        if (file) { return file->getName().str(); }
+        if (file) { return normalizeAbsolutePath(file->getName().str()); }
 
         if (auto oldFile = SM.getFileEntryRefForID(fid)) {
-            return oldFile->getName().str();
+            return normalizeAbsolutePath(oldFile->getName().str());
         }
 
         return {};
@@ -64,6 +76,7 @@ struct BranchingIncludeCollectorCallback : public clang::PPCallbacks {
         std::string IncludingFilePath;
         std::string RelativePath;
         std::string AbsolutePath;
+        unsigned    PhysicalLine = 0;
     };
 
     struct VisitFrame {
@@ -89,6 +102,7 @@ struct BranchingIncludeCollectorCallback : public clang::PPCallbacks {
         Root = Out->mutable_mainfileincludetree();
         Root->set_absolutepath(getMainFileAbsolutePathFromSM());
         Root->set_relativepath("");
+        Root->set_physicalline(0);
 
         clang::FileID mainId = SM->getMainFileID();
 
@@ -107,9 +121,9 @@ struct BranchingIncludeCollectorCallback : public clang::PPCallbacks {
         clang::FileID               mainId = SM->getMainFileID();
         clang::OptionalFileEntryRef file   = SM->getFileEntryRefForID(mainId);
         if (file) {
-            return file->getName().str();
+            return normalizeAbsolutePath(file->getName().str());
         } else if (auto oldFile = SM->getFileEntryRefForID(mainId)) {
-            return oldFile->getName().str();
+            return normalizeAbsolutePath(oldFile->getName().str());
         } else {
             return {};
         }
@@ -167,11 +181,13 @@ struct BranchingIncludeCollectorCallback : public clang::PPCallbacks {
 
         if (pending) {
             nested->set_relativepath(pending->RelativePath);
+            nested->set_physicalline(pending->PhysicalLine);
             if (nested->absolutepath().empty()) {
                 nested->set_absolutepath(pending->AbsolutePath);
             }
         } else {
             nested->set_relativepath("");
+            nested->set_physicalline(0);
         }
 
         ActiveStack.push_back(
@@ -204,14 +220,19 @@ struct BranchingIncludeCollectorCallback : public clang::PPCallbacks {
 
         if (File && SM->isInMainFile(HashLoc)) {
             auto incl = Out->add_includes();
-            incl->set_absolutepath(File->getName().str());
+            incl->set_absolutepath(normalizeAbsolutePath(File->getName().str()));
             incl->set_relativepath(FileName.str());
         }
 
         PendingInclude pending;
         pending.IncludingFilePath = getRealPathForLoc(*SM, HashLoc);
         pending.RelativePath      = FileName.str();
-        if (File) { pending.AbsolutePath = File->getName().str(); }
+        if (File) { pending.AbsolutePath = normalizeAbsolutePath(File->getName().str()); }
+
+        clang::SourceLocation spelling = SM->getSpellingLoc(HashLoc);
+        if (spelling.isValid()) {
+            pending.PhysicalLine = SM->getSpellingLineNumber(spelling);
+        }
 
         PendingIncludes.push_back(std::move(pending));
     }

--- a/scripts/cxx_codegen/branching_include_collector.hpp
+++ b/scripts/cxx_codegen/branching_include_collector.hpp
@@ -102,7 +102,7 @@ struct BranchingIncludeCollectorCallback : public clang::PPCallbacks {
         Root = Out->mutable_mainfileincludetree();
         Root->set_absolutepath(getMainFileAbsolutePathFromSM());
         Root->set_relativepath("");
-        Root->set_physicalline(0);
+        Root->set_includelocationline(0);
 
         clang::FileID mainId = SM->getMainFileID();
 
@@ -114,7 +114,7 @@ struct BranchingIncludeCollectorCallback : public clang::PPCallbacks {
                 .ProcessedLines = {},
             });
 
-        Root->set_directlinecount(countPhysicalLines(*SM, mainId));
+        Root->set_filelinecount(countPhysicalLines(*SM, mainId));
     }
 
     std::string getMainFileAbsolutePathFromSM() {
@@ -177,17 +177,17 @@ struct BranchingIncludeCollectorCallback : public clang::PPCallbacks {
 
         IncludeVisit* nested = ActiveStack.back().Node->add_nested();
         nested->set_absolutepath(enteredPath);
-        nested->set_directlinecount(countPhysicalLines(*SM, enteredFile));
+        nested->set_filelinecount(countPhysicalLines(*SM, enteredFile));
 
         if (pending) {
             nested->set_relativepath(pending->RelativePath);
-            nested->set_physicalline(pending->PhysicalLine);
+            nested->set_includelocationline(pending->PhysicalLine);
             if (nested->absolutepath().empty()) {
                 nested->set_absolutepath(pending->AbsolutePath);
             }
         } else {
             nested->set_relativepath("");
-            nested->set_physicalline(0);
+            nested->set_includelocationline(0);
         }
 
         ActiveStack.push_back(
@@ -327,14 +327,7 @@ struct BranchingIncludeCollectorCallback : public clang::PPCallbacks {
         VisitFrame& top = ActiveStack.back();
 
         unsigned selfLines = static_cast<unsigned>(top.ProcessedLines.size());
-        top.Node->set_expandedlinecountwithoutnested(selfLines);
-
-        unsigned withnested = selfLines;
-        for (int i = 0; i < top.Node->nested_size(); ++i) {
-            withnested += top.Node->nested(i).expandedlinecountwithnested();
-        }
-
-        top.Node->set_expandedlinecountwithnested(withnested);
+        top.Node->set_directexpandedlines(selfLines);
     }
 
     void exitFile() {

--- a/scripts/cxx_codegen/branching_include_collector.hpp
+++ b/scripts/cxx_codegen/branching_include_collector.hpp
@@ -1,0 +1,324 @@
+#pragma once
+
+#include <clang/AST/ASTConsumer.h>
+#include <clang/AST/RecursiveASTVisitor.h>
+#include <clang/Frontend/FrontendPluginRegistry.h>
+#include <clang/Frontend/CompilerInstance.h>
+#include <clang/Frontend/ASTConsumers.h>
+
+#include <hstd/stdlib/Set.hpp>
+
+#include "reflection_config.hpp"
+#include "reflection_defs.pb.h"
+
+
+struct BranchingIncludeCollectorCallback : public clang::PPCallbacks {
+    clang::SourceManager* SM;
+    clang::Preprocessor*  PP;
+    TU*                   Out;
+
+    IncludeVisit* Root = nullptr;
+
+    static std::string getMainFileAbsolutePath(clang::CompilerInstance& CI) {
+        clang::SourceManager&       SM     = CI.getSourceManager();
+        clang::FileID               mainId = SM.getMainFileID();
+        clang::OptionalFileEntryRef file   = SM.getFileEntryRefForID(mainId);
+        if (file) {
+            return file->getName().str();
+        } else {
+            return SM.getFileEntryRefForID(mainId)->getName().str();
+        }
+    }
+
+    static std::string getRealPathForLoc(
+        clang::SourceManager const& SM,
+        clang::SourceLocation       Loc) {
+        clang::SourceLocation spelling = SM.getSpellingLoc(Loc);
+        if (spelling.isInvalid()) { return {}; }
+
+        clang::FileID               fid  = SM.getFileID(spelling);
+        clang::OptionalFileEntryRef file = SM.getFileEntryRefForID(fid);
+        if (file) { return file->getName().str(); }
+
+        if (auto oldFile = SM.getFileEntryRefForID(fid)) {
+            return oldFile->getName().str();
+        }
+
+        return {};
+    }
+
+    static unsigned countPhysicalLines(
+        clang::SourceManager const& SM,
+        clang::FileID               fid) {
+        llvm::StringRef data = SM.getBufferData(fid);
+        if (data.empty()) { return 0; }
+
+        unsigned lines = 1;
+        for (char c : data) {
+            if (c == '\n') { ++lines; }
+        }
+        return lines;
+    }
+
+    struct PendingInclude {
+        std::string IncludingFilePath;
+        std::string RelativePath;
+        std::string AbsolutePath;
+    };
+
+    struct VisitFrame {
+        IncludeVisit*                Node;
+        clang::FileID                File;
+        std::string                  AbsolutePath;
+        std::unordered_set<unsigned> ProcessedLines;
+    };
+
+
+    std::vector<VisitFrame>    ActiveStack;
+    std::deque<PendingInclude> PendingIncludes;
+
+    BranchingIncludeCollectorCallback(
+        TU*                   tu,
+        clang::SourceManager* sourceManager,
+        clang::Preprocessor*  preprocessor)
+        : SM(sourceManager), PP(preprocessor), Out(tu) {}
+
+    void ensureRoot() {
+        if (Root) { return; }
+
+        Root = Out->mutable_mainfileincludetree();
+        Root->set_absolutepath(getMainFileAbsolutePathFromSM());
+        Root->set_relativepath("");
+
+        clang::FileID mainId = SM->getMainFileID();
+
+        ActiveStack.push_back(
+            VisitFrame{
+                .Node           = Root,
+                .File           = mainId,
+                .AbsolutePath   = Root->absolutepath(),
+                .ProcessedLines = {},
+            });
+
+        Root->set_directlinecount(countPhysicalLines(*SM, mainId));
+    }
+
+    std::string getMainFileAbsolutePathFromSM() {
+        clang::FileID               mainId = SM->getMainFileID();
+        clang::OptionalFileEntryRef file   = SM->getFileEntryRefForID(mainId);
+        if (file) {
+            return file->getName().str();
+        } else if (auto oldFile = SM->getFileEntryRefForID(mainId)) {
+            return oldFile->getName().str();
+        } else {
+            return {};
+        }
+    }
+
+    void markLine(clang::SourceLocation Loc) {
+        if (ActiveStack.empty()) { return; }
+
+        clang::SourceLocation spelling = SM->getSpellingLoc(Loc);
+        if (spelling.isInvalid()) { return; }
+
+        clang::FileID fid = SM->getFileID(spelling);
+        VisitFrame&   top = ActiveStack.back();
+        if (fid != top.File) { return; }
+
+        unsigned line = SM->getSpellingLineNumber(spelling);
+        if (line != 0) { top.ProcessedLines.insert(line); }
+    }
+
+    void finalizeTop() {
+        VisitFrame& top = ActiveStack.back();
+
+        unsigned selfLines = static_cast<unsigned>(top.ProcessedLines.size());
+        top.Node->set_expandedlinecountwithoutnested(selfLines);
+
+        unsigned withnested = selfLines;
+        for (int i = 0; i < top.Node->nested_size(); ++i) {
+            withnested += top.Node->nested(i).expandedlinecountwithnested();
+        }
+
+        top.Node->set_expandedlinecountwithnested(withnested);
+    }
+
+    std::optional<PendingInclude> popPendingForParent(std::string const& parentPath) {
+        for (auto it = PendingIncludes.begin(); it != PendingIncludes.end(); ++it) {
+            if (it->IncludingFilePath == parentPath) {
+                PendingInclude result = *it;
+                PendingIncludes.erase(it);
+                return result;
+            }
+        }
+        return std::nullopt;
+    }
+
+    void enterFile(clang::SourceLocation Loc) {
+        if (!Root) { ensureRoot(); }
+
+        clang::SourceLocation spelling = SM->getSpellingLoc(Loc);
+        if (spelling.isInvalid()) { return; }
+
+        clang::FileID enteredFile = SM->getFileID(spelling);
+
+        if (!ActiveStack.empty() && ActiveStack.back().File == enteredFile) { return; }
+
+        if (ActiveStack.empty()) { return; }
+
+        std::string enteredPath = getRealPathForLoc(*SM, spelling);
+        std::string parentPath  = ActiveStack.back().AbsolutePath;
+
+        auto pending = popPendingForParent(parentPath);
+
+        IncludeVisit* nested = ActiveStack.back().Node->add_nested();
+        nested->set_absolutepath(enteredPath);
+        nested->set_directlinecount(countPhysicalLines(*SM, enteredFile));
+
+        if (pending) {
+            nested->set_relativepath(pending->RelativePath);
+            if (nested->absolutepath().empty()) {
+                nested->set_absolutepath(pending->AbsolutePath);
+            }
+        } else {
+            nested->set_relativepath("");
+        }
+
+        ActiveStack.push_back(
+            VisitFrame{
+                .Node           = nested,
+                .File           = enteredFile,
+                .AbsolutePath   = nested->absolutepath(),
+                .ProcessedLines = {},
+            });
+
+        markLine(Loc);
+    }
+
+    void exitFile() {
+        if (ActiveStack.empty()) { return; }
+
+        finalizeTop();
+        ActiveStack.pop_back();
+    }
+
+    void InclusionDirective(
+        clang::SourceLocation HashLoc,
+        clang::Token const&,
+        llvm::StringRef FileName,
+        bool,
+        clang::CharSourceRange,
+        clang::OptionalFileEntryRef File,
+        llvm::StringRef,
+        llvm::StringRef,
+        clang::Module const*,
+        bool,
+        clang::SrcMgr::CharacteristicKind) override {
+
+        ensureRoot();
+        markLine(HashLoc);
+
+        if (File && SM->isInMainFile(HashLoc)) {
+            auto incl = Out->add_includes();
+            incl->set_absolutepath(File->getName().str());
+            incl->set_relativepath(FileName.str());
+        }
+
+        PendingInclude pending;
+        pending.IncludingFilePath = getRealPathForLoc(*SM, HashLoc);
+        pending.RelativePath      = FileName.str();
+        if (File) { pending.AbsolutePath = File->getName().str(); }
+
+        PendingIncludes.push_back(std::move(pending));
+    }
+
+    void FileChanged(
+        clang::SourceLocation                Loc,
+        clang::PPCallbacks::FileChangeReason Reason,
+        clang::SrcMgr::CharacteristicKind,
+        clang::FileID PrevFID) override {
+
+        if (!Root) { ensureRoot(); }
+
+        switch (Reason) {
+            case clang::PPCallbacks::EnterFile: enterFile(Loc); break;
+
+            case clang::PPCallbacks::ExitFile:
+                if (!ActiveStack.empty() && ActiveStack.back().File == PrevFID) {
+                    markLine(Loc);
+                    exitFile();
+                } else if (ActiveStack.size() > 1) {
+                    exitFile();
+                }
+                break;
+
+            case clang::PPCallbacks::RenameFile:
+            case clang::PPCallbacks::SystemHeaderPragma: break;
+        }
+    }
+
+    void If(clang::SourceLocation Loc, clang::SourceRange, ConditionValueKind) override {
+        markLine(Loc);
+    }
+
+    void Elif(
+        clang::SourceLocation Loc,
+        clang::SourceRange,
+        ConditionValueKind,
+        clang::SourceLocation) override {
+        markLine(Loc);
+    }
+
+    void Ifdef(
+        clang::SourceLocation Loc,
+        clang::Token const&,
+        clang::MacroDefinition const&) override {
+        markLine(Loc);
+    }
+
+    void Ifndef(
+        clang::SourceLocation Loc,
+        clang::Token const&,
+        clang::MacroDefinition const&) override {
+        markLine(Loc);
+    }
+
+    void Else(clang::SourceLocation Loc, clang::SourceLocation) override {
+        markLine(Loc);
+    }
+
+    void Endif(clang::SourceLocation Loc, clang::SourceLocation) override {
+        markLine(Loc);
+    }
+
+    void MacroDefined(clang::Token const& Tok, clang::MacroDirective const*) override {
+        markLine(Tok.getLocation());
+    }
+
+    void MacroUndefined(
+        clang::Token const& Tok,
+        clang::MacroDefinition const&,
+        clang::MacroDirective const*) override {
+        markLine(Tok.getLocation());
+    }
+
+    void MacroExpands(
+        clang::Token const&,
+        clang::MacroDefinition const&,
+        clang::SourceRange Range,
+        clang::MacroArgs const*) override {
+        markLine(Range.getBegin());
+    }
+
+    void PragmaDirective(clang::SourceLocation Loc, clang::PragmaIntroducerKind)
+        override {
+        markLine(Loc);
+    }
+
+    ~BranchingIncludeCollectorCallback() override {
+        while (!ActiveStack.empty()) {
+            finalizeTop();
+            ActiveStack.pop_back();
+        }
+    }
+};

--- a/scripts/cxx_codegen/branching_include_collector.hpp
+++ b/scripts/cxx_codegen/branching_include_collector.hpp
@@ -129,19 +129,6 @@ struct BranchingIncludeCollectorCallback : public clang::PPCallbacks {
         if (line != 0) { top.ProcessedLines.insert(line); }
     }
 
-    void finalizeTop() {
-        VisitFrame& top = ActiveStack.back();
-
-        unsigned selfLines = static_cast<unsigned>(top.ProcessedLines.size());
-        top.Node->set_expandedlinecountwithoutnested(selfLines);
-
-        unsigned withnested = selfLines;
-        for (int i = 0; i < top.Node->nested_size(); ++i) {
-            withnested += top.Node->nested(i).expandedlinecountwithnested();
-        }
-
-        top.Node->set_expandedlinecountwithnested(withnested);
-    }
 
     std::optional<PendingInclude> popPendingForParent(std::string const& parentPath) {
         for (auto it = PendingIncludes.begin(); it != PendingIncludes.end(); ++it) {
@@ -161,6 +148,9 @@ struct BranchingIncludeCollectorCallback : public clang::PPCallbacks {
         if (spelling.isInvalid()) { return; }
 
         clang::FileID enteredFile = SM->getFileID(spelling);
+
+        auto fe = SM->getFileEntryRefForID(enteredFile);
+        if (!fe) { return; } // skip non-physical files
 
         if (!ActiveStack.empty() && ActiveStack.back().File == enteredFile) { return; }
 
@@ -195,12 +185,6 @@ struct BranchingIncludeCollectorCallback : public clang::PPCallbacks {
         markLine(Loc);
     }
 
-    void exitFile() {
-        if (ActiveStack.empty()) { return; }
-
-        finalizeTop();
-        ActiveStack.pop_back();
-    }
 
     void InclusionDirective(
         clang::SourceLocation HashLoc,
@@ -315,10 +299,44 @@ struct BranchingIncludeCollectorCallback : public clang::PPCallbacks {
         markLine(Loc);
     }
 
-    ~BranchingIncludeCollectorCallback() override {
+
+    bool Finalized = false;
+
+    void finalizeTop() {
+        VisitFrame& top = ActiveStack.back();
+
+        unsigned selfLines = static_cast<unsigned>(top.ProcessedLines.size());
+        top.Node->set_expandedlinecountwithoutnested(selfLines);
+
+        unsigned withnested = selfLines;
+        for (int i = 0; i < top.Node->nested_size(); ++i) {
+            withnested += top.Node->nested(i).expandedlinecountwithnested();
+        }
+
+        top.Node->set_expandedlinecountwithnested(withnested);
+    }
+
+    void exitFile() {
+        if (ActiveStack.empty()) { return; }
+
+        finalizeTop();
+        ActiveStack.pop_back();
+    }
+
+
+    void finalizeAll() {
+        if (Finalized) { return; }
         while (!ActiveStack.empty()) {
             finalizeTop();
             ActiveStack.pop_back();
         }
+        Finalized = true;
     }
+
+    void EndOfMainFile() override {
+        if (!Root) { ensureRoot(); }
+        finalizeAll();
+    }
+
+    ~BranchingIncludeCollectorCallback() override { finalizeAll(); }
 };

--- a/scripts/cxx_codegen/branching_include_collector.hpp
+++ b/scripts/cxx_codegen/branching_include_collector.hpp
@@ -133,59 +133,42 @@ struct BranchingIncludeCollectorCallback : public clang::PPCallbacks {
         unsigned           includeLine,
         std::string const& enteredPath) {
 
-        auto isParentMatch = [&](PendingInclude const& p) {
-            return p.IncludingFilePath == parentPath;
-        };
-
-        auto isStrongMatch = [&](PendingInclude const& p) {
-            if (!isParentMatch(p)) { return false; }
-            if (includeLine != 0 && p.PhysicalLine != includeLine) { return false; }
-            if (!enteredPath.empty() && !p.AbsolutePath.empty()
-                && p.AbsolutePath != enteredPath) {
-                return false;
-            }
-            return true;
-        };
-
         for (auto it = PendingIncludes.begin(); it != PendingIncludes.end(); ++it) {
-            if (isStrongMatch(*it)) {
-                PendingInclude result = *it;
-                PendingIncludes.erase(it);
-                return result;
+            if (it->IncludingFilePath != parentPath) { continue; }
+            if (includeLine == 0 || it->PhysicalLine != includeLine) { continue; }
+            if (!enteredPath.empty() && !it->AbsolutePath.empty()
+                && it->AbsolutePath != enteredPath) {
+                continue;
             }
-        }
 
-        for (auto it = PendingIncludes.begin(); it != PendingIncludes.end(); ++it) {
-            if (isParentMatch(*it)) {
-                PendingInclude result = *it;
-                PendingIncludes.erase(it);
-                return result;
-            }
+            PendingInclude result = *it;
+            PendingIncludes.erase(it);
+            return result;
         }
 
         return std::nullopt;
     }
 
-    void enterFile(clang::SourceLocation Loc) {
+    void enterFile(clang::FileID enteredFile) {
         if (!Root) { ensureRoot(); }
 
-        clang::SourceLocation spelling = SM->getSpellingLoc(Loc);
-        if (spelling.isInvalid()) { return; }
-
-        clang::FileID enteredFile = SM->getFileID(spelling);
-
         auto fe = SM->getFileEntryRefForID(enteredFile);
-        if (!fe) { return; } // skip non-physical files
+        if (!fe) { return; }
 
         if (!ActiveStack.empty() && ActiveStack.back().File == enteredFile) { return; }
-
         if (ActiveStack.empty()) { return; }
 
-        std::string enteredPath = getRealPathForLoc(*SM, spelling);
-        std::string parentPath  = ActiveStack.back().AbsolutePath;
+        std::string enteredPath = normalizeAbsolutePath(fe->getName().str());
 
-        unsigned includeLine = 0;
-        if (spelling.isValid()) { includeLine = SM->getSpellingLineNumber(spelling); }
+        clang::SourceLocation includeLoc = SM->getIncludeLoc(enteredFile);
+        std::string           parentPath;
+        unsigned              includeLine = 0;
+        if (includeLoc.isValid()) {
+            parentPath  = getRealPathForLoc(*SM, includeLoc);
+            includeLine = SM->getSpellingLineNumber(SM->getSpellingLoc(includeLoc));
+        } else {
+            parentPath = ActiveStack.back().AbsolutePath;
+        }
 
         auto pending = popPendingForParent(parentPath, includeLine, enteredPath);
 
@@ -196,9 +179,6 @@ struct BranchingIncludeCollectorCallback : public clang::PPCallbacks {
         if (pending) {
             nested->set_relativepath(pending->RelativePath);
             nested->set_includelocationline(pending->PhysicalLine);
-            if (nested->absolutepath().empty()) {
-                nested->set_absolutepath(pending->AbsolutePath);
-            }
         } else {
             nested->set_relativepath("");
             nested->set_includelocationline(0);
@@ -211,7 +191,6 @@ struct BranchingIncludeCollectorCallback : public clang::PPCallbacks {
                 .AbsolutePath = nested->absolutepath(),
             });
     }
-
 
     void InclusionDirective(
         clang::SourceLocation HashLoc,
@@ -247,6 +226,19 @@ struct BranchingIncludeCollectorCallback : public clang::PPCallbacks {
         PendingIncludes.push_back(std::move(pending));
     }
 
+    void FileSkipped(
+        clang::FileEntryRef const& SkippedFile,
+        clang::Token const&        FilenameTok,
+        clang::SrcMgr::CharacteristicKind) override {
+
+        std::string parentPath = getRealPathForLoc(*SM, FilenameTok.getLocation());
+        unsigned    line       = SM->getSpellingLineNumber(
+            SM->getSpellingLoc(FilenameTok.getLocation()));
+        std::string skippedAbs = normalizeAbsolutePath(SkippedFile.getName().str());
+
+        (void)popPendingForParent(parentPath, line, skippedAbs);
+    }
+
     void FileChanged(
         clang::SourceLocation                Loc,
         clang::PPCallbacks::FileChangeReason Reason,
@@ -256,7 +248,14 @@ struct BranchingIncludeCollectorCallback : public clang::PPCallbacks {
         if (!Root) { ensureRoot(); }
 
         switch (Reason) {
-            case clang::PPCallbacks::EnterFile: enterFile(Loc); break;
+            case clang::PPCallbacks::EnterFile: {
+                clang::SourceLocation enterLoc = SM->getExpansionLoc(Loc);
+                if (enterLoc.isValid()) {
+                    clang::FileID entered = SM->getFileID(enterLoc);
+                    enterFile(entered);
+                }
+                break;
+            }
 
             case clang::PPCallbacks::ExitFile:
                 if (!ActiveStack.empty() && ActiveStack.back().File == PrevFID) {

--- a/scripts/cxx_codegen/branching_include_collector.hpp
+++ b/scripts/cxx_codegen/branching_include_collector.hpp
@@ -72,10 +72,11 @@ struct BranchingIncludeCollectorCallback : public clang::PPCallbacks {
     }
 
     struct PendingInclude {
-        std::string IncludingFilePath;
-        std::string RelativePath;
-        std::string AbsolutePath;
-        unsigned    PhysicalLine = 0;
+        clang::FileID ParentFile;
+        std::string   RelativePath;
+        std::string   AbsolutePath;
+        unsigned      PhysicalLine = 0;
+        IncludeVisit* Node         = nullptr;
     };
 
     struct VisitFrame {
@@ -129,12 +130,12 @@ struct BranchingIncludeCollectorCallback : public clang::PPCallbacks {
 
 
     std::optional<PendingInclude> popPendingForParent(
-        std::string const& parentPath,
-        unsigned           includeLine,
-        std::string const& enteredPath) {
+        clang::FileID const& parentFile,
+        unsigned             includeLine,
+        std::string const&   enteredPath) {
 
         for (auto it = PendingIncludes.begin(); it != PendingIncludes.end(); ++it) {
-            if (it->IncludingFilePath != parentPath) { continue; }
+            if (it->ParentFile != parentFile) { continue; }
             if (includeLine == 0 || it->PhysicalLine != includeLine) { continue; }
             if (!enteredPath.empty() && !it->AbsolutePath.empty()
                 && it->AbsolutePath != enteredPath) {
@@ -161,34 +162,26 @@ struct BranchingIncludeCollectorCallback : public clang::PPCallbacks {
         std::string enteredPath = normalizeAbsolutePath(fe->getName().str());
 
         clang::SourceLocation includeLoc = SM->getIncludeLoc(enteredFile);
-        std::string           parentPath;
-        unsigned              includeLine = 0;
-        if (includeLoc.isValid()) {
-            parentPath  = getRealPathForLoc(*SM, includeLoc);
-            includeLine = SM->getSpellingLineNumber(SM->getSpellingLoc(includeLoc));
-        } else {
-            parentPath = ActiveStack.back().AbsolutePath;
-        }
+        if (!includeLoc.isValid()) { return; }
 
-        auto pending = popPendingForParent(parentPath, includeLine, enteredPath);
+        clang::SourceLocation includeSpelling = SM->getSpellingLoc(includeLoc);
+        if (includeSpelling.isInvalid()) { return; }
 
-        IncludeVisit* nested = ActiveStack.back().Node->add_nested();
-        nested->set_absolutepath(enteredPath);
-        nested->set_filelinecount(countPhysicalLines(*SM, enteredFile));
+        clang::FileID parentFid   = SM->getFileID(includeSpelling);
+        unsigned      includeLine = SM->getSpellingLineNumber(includeSpelling);
 
-        if (pending) {
-            nested->set_relativepath(pending->RelativePath);
-            nested->set_includelocationline(pending->PhysicalLine);
-        } else {
-            nested->set_relativepath("");
-            nested->set_includelocationline(0);
-        }
+        auto pending = popPendingForParent(parentFid, includeLine, enteredPath);
+        if (!pending || !pending->Node) { return; }
+
+        IncludeVisit* node = pending->Node;
+        if (node->absolutepath().empty()) { node->set_absolutepath(enteredPath); }
+        node->set_filelinecount(countPhysicalLines(*SM, enteredFile));
 
         ActiveStack.push_back(
             VisitFrame{
-                .Node         = nested,
+                .Node         = node,
                 .File         = enteredFile,
-                .AbsolutePath = nested->absolutepath(),
+                .AbsolutePath = node->absolutepath(),
             });
     }
 
@@ -206,24 +199,37 @@ struct BranchingIncludeCollectorCallback : public clang::PPCallbacks {
         clang::SrcMgr::CharacteristicKind) override {
 
         ensureRoot();
+        if (ActiveStack.empty()) { return; }
+
+        clang::SourceLocation spelling = SM->getSpellingLoc(HashLoc);
+        if (spelling.isInvalid()) { return; }
+
+        clang::FileID parentFid = SM->getFileID(spelling);
+        unsigned      line      = SM->getSpellingLineNumber(spelling);
+
+        IncludeVisit* nested = ActiveStack.back().Node->add_nested();
+        nested->set_relativepath(FileName.str());
+        nested->set_includelocationline(line);
+        if (File) {
+            nested->set_absolutepath(normalizeAbsolutePath(File->getName().str()));
+        } else {
+            nested->set_absolutepath("");
+        }
+
+        PendingInclude pending;
+        pending.ParentFile   = parentFid;
+        pending.RelativePath = FileName.str();
+        pending.PhysicalLine = line;
+        pending.Node         = nested;
+        if (File) { pending.AbsolutePath = normalizeAbsolutePath(File->getName().str()); }
+
+        PendingIncludes.push_back(std::move(pending));
 
         if (File && SM->isInMainFile(HashLoc)) {
             auto incl = Out->add_includes();
             incl->set_absolutepath(normalizeAbsolutePath(File->getName().str()));
             incl->set_relativepath(FileName.str());
         }
-
-        PendingInclude pending;
-        pending.IncludingFilePath = getRealPathForLoc(*SM, HashLoc);
-        pending.RelativePath      = FileName.str();
-        if (File) { pending.AbsolutePath = normalizeAbsolutePath(File->getName().str()); }
-
-        clang::SourceLocation spelling = SM->getSpellingLoc(HashLoc);
-        if (spelling.isValid()) {
-            pending.PhysicalLine = SM->getSpellingLineNumber(spelling);
-        }
-
-        PendingIncludes.push_back(std::move(pending));
     }
 
     void FileSkipped(
@@ -231,12 +237,14 @@ struct BranchingIncludeCollectorCallback : public clang::PPCallbacks {
         clang::Token const&        FilenameTok,
         clang::SrcMgr::CharacteristicKind) override {
 
-        std::string parentPath = getRealPathForLoc(*SM, FilenameTok.getLocation());
-        unsigned    line       = SM->getSpellingLineNumber(
-            SM->getSpellingLoc(FilenameTok.getLocation()));
-        std::string skippedAbs = normalizeAbsolutePath(SkippedFile.getName().str());
+        clang::SourceLocation loc = SM->getSpellingLoc(FilenameTok.getLocation());
+        if (loc.isInvalid()) { return; }
 
-        (void)popPendingForParent(parentPath, line, skippedAbs);
+        clang::FileID parentFid  = SM->getFileID(loc);
+        unsigned      line       = SM->getSpellingLineNumber(loc);
+        std::string   skippedAbs = normalizeAbsolutePath(SkippedFile.getName().str());
+
+        (void)popPendingForParent(parentFid, line, skippedAbs);
     }
 
     void FileChanged(

--- a/scripts/cxx_codegen/branching_include_collector.hpp
+++ b/scripts/cxx_codegen/branching_include_collector.hpp
@@ -26,8 +26,7 @@ struct BranchingIncludeCollectorCallback : public clang::PPCallbacks {
         std::filesystem::path p(rawPath);
         if (p.is_relative()) { p = std::filesystem::absolute(p); }
 
-        p = p.lexically_normal();
-        return p.string();
+        return std::filesystem::canonical(p).string();
     }
 
     static std::string getMainFileAbsolutePath(clang::CompilerInstance& CI) {
@@ -83,7 +82,7 @@ struct BranchingIncludeCollectorCallback : public clang::PPCallbacks {
         IncludeVisit*                Node;
         clang::FileID                File;
         std::string                  AbsolutePath;
-        std::unordered_set<unsigned> ProcessedLines;
+        std::unordered_set<unsigned> SkippedLines;
     };
 
 
@@ -108,10 +107,9 @@ struct BranchingIncludeCollectorCallback : public clang::PPCallbacks {
 
         ActiveStack.push_back(
             VisitFrame{
-                .Node           = Root,
-                .File           = mainId,
-                .AbsolutePath   = Root->absolutepath(),
-                .ProcessedLines = {},
+                .Node         = Root,
+                .File         = mainId,
+                .AbsolutePath = Root->absolutepath(),
             });
 
         Root->set_filelinecount(countPhysicalLines(*SM, mainId));
@@ -127,20 +125,6 @@ struct BranchingIncludeCollectorCallback : public clang::PPCallbacks {
         } else {
             return {};
         }
-    }
-
-    void markLine(clang::SourceLocation Loc) {
-        if (ActiveStack.empty()) { return; }
-
-        clang::SourceLocation spelling = SM->getSpellingLoc(Loc);
-        if (spelling.isInvalid()) { return; }
-
-        clang::FileID fid = SM->getFileID(spelling);
-        VisitFrame&   top = ActiveStack.back();
-        if (fid != top.File) { return; }
-
-        unsigned line = SM->getSpellingLineNumber(spelling);
-        if (line != 0) { top.ProcessedLines.insert(line); }
     }
 
 
@@ -192,13 +176,10 @@ struct BranchingIncludeCollectorCallback : public clang::PPCallbacks {
 
         ActiveStack.push_back(
             VisitFrame{
-                .Node           = nested,
-                .File           = enteredFile,
-                .AbsolutePath   = nested->absolutepath(),
-                .ProcessedLines = {},
+                .Node         = nested,
+                .File         = enteredFile,
+                .AbsolutePath = nested->absolutepath(),
             });
-
-        markLine(Loc);
     }
 
 
@@ -216,7 +197,6 @@ struct BranchingIncludeCollectorCallback : public clang::PPCallbacks {
         clang::SrcMgr::CharacteristicKind) override {
 
         ensureRoot();
-        markLine(HashLoc);
 
         if (File && SM->isInMainFile(HashLoc)) {
             auto incl = Out->add_includes();
@@ -250,7 +230,6 @@ struct BranchingIncludeCollectorCallback : public clang::PPCallbacks {
 
             case clang::PPCallbacks::ExitFile:
                 if (!ActiveStack.empty() && ActiveStack.back().File == PrevFID) {
-                    markLine(Loc);
                     exitFile();
                 } else if (ActiveStack.size() > 1) {
                     exitFile();
@@ -262,62 +241,28 @@ struct BranchingIncludeCollectorCallback : public clang::PPCallbacks {
         }
     }
 
-    void If(clang::SourceLocation Loc, clang::SourceRange, ConditionValueKind) override {
-        markLine(Loc);
-    }
+    void SourceRangeSkipped(clang::SourceRange Range, clang::SourceLocation) override {
+        if (ActiveStack.empty()) { return; }
 
-    void Elif(
-        clang::SourceLocation Loc,
-        clang::SourceRange,
-        ConditionValueKind,
-        clang::SourceLocation) override {
-        markLine(Loc);
-    }
+        clang::SourceLocation begin = SM->getSpellingLoc(Range.getBegin());
+        clang::SourceLocation end   = SM->getSpellingLoc(Range.getEnd());
+        if (begin.isInvalid() || end.isInvalid()) { return; }
 
-    void Ifdef(
-        clang::SourceLocation Loc,
-        clang::Token const&,
-        clang::MacroDefinition const&) override {
-        markLine(Loc);
-    }
+        clang::FileID fidBegin = SM->getFileID(begin);
+        clang::FileID fidEnd   = SM->getFileID(end);
+        if (fidBegin != fidEnd) { return; }
 
-    void Ifndef(
-        clang::SourceLocation Loc,
-        clang::Token const&,
-        clang::MacroDefinition const&) override {
-        markLine(Loc);
-    }
+        VisitFrame& top = ActiveStack.back();
+        if (fidBegin != top.File) { return; }
 
-    void Else(clang::SourceLocation Loc, clang::SourceLocation) override {
-        markLine(Loc);
-    }
+        unsigned lineBegin = SM->getSpellingLineNumber(begin);
+        unsigned lineEnd   = SM->getSpellingLineNumber(end);
+        if (lineBegin == 0 || lineEnd == 0) { return; }
+        if (lineEnd < lineBegin) { std::swap(lineBegin, lineEnd); }
 
-    void Endif(clang::SourceLocation Loc, clang::SourceLocation) override {
-        markLine(Loc);
-    }
-
-    void MacroDefined(clang::Token const& Tok, clang::MacroDirective const*) override {
-        markLine(Tok.getLocation());
-    }
-
-    void MacroUndefined(
-        clang::Token const& Tok,
-        clang::MacroDefinition const&,
-        clang::MacroDirective const*) override {
-        markLine(Tok.getLocation());
-    }
-
-    void MacroExpands(
-        clang::Token const&,
-        clang::MacroDefinition const&,
-        clang::SourceRange Range,
-        clang::MacroArgs const*) override {
-        markLine(Range.getBegin());
-    }
-
-    void PragmaDirective(clang::SourceLocation Loc, clang::PragmaIntroducerKind)
-        override {
-        markLine(Loc);
+        for (unsigned line = lineBegin; line <= lineEnd; ++line) {
+            top.SkippedLines.insert(line);
+        }
     }
 
 
@@ -326,8 +271,11 @@ struct BranchingIncludeCollectorCallback : public clang::PPCallbacks {
     void finalizeTop() {
         VisitFrame& top = ActiveStack.back();
 
-        unsigned selfLines = static_cast<unsigned>(top.ProcessedLines.size());
-        top.Node->set_directexpandedlines(selfLines);
+        unsigned total   = top.Node->filelinecount();
+        unsigned skipped = static_cast<unsigned>(top.SkippedLines.size());
+        unsigned direct  = (total > skipped) ? (total - skipped) : 0;
+
+        top.Node->set_usedlinecount(direct);
     }
 
     void exitFile() {

--- a/scripts/cxx_codegen/reflection_collector.cpp
+++ b/scripts/cxx_codegen/reflection_collector.cpp
@@ -19,6 +19,7 @@
 #include <hstd/ext/logger.hpp>
 
 #include <clang/AST/NestedNameSpecifierBase.h>
+#include "branching_include_collector.hpp"
 
 namespace c = clang;
 using llvm::dyn_cast;
@@ -1652,6 +1653,10 @@ ReflASTConsumer::ReflASTConsumer(clang::CompilerInstance& CI, ReflectionCLI cons
         out.get(), &CI.getSourceManager());
     out->set_absolutepath(getMainFileAbsolutePath(CI));
     CI.getPreprocessor().addPPCallbacks(std::move(callback));
+
+    CI.getPreprocessor().addPPCallbacks(
+        std::make_unique<BranchingIncludeCollectorCallback>(
+            out.get(), &CI.getSourceManager(), &CI.getPreprocessor()));
 }
 
 void ReflASTConsumer::HandleTranslationUnit(c::ASTContext& Context) {

--- a/scripts/cxx_codegen/reflection_defs.proto
+++ b/scripts/cxx_codegen/reflection_defs.proto
@@ -245,7 +245,8 @@ message IncludeVisit {
     uint32 DirectLineCount = 3;
     uint32 ExpandedLineCountWithNested = 4;
     uint32 ExpandedLineCountWithoutNested = 5;
-    repeated IncludeVisit Nested = 6;
+    uint32 PhysicalLine = 6;
+    repeated IncludeVisit Nested = 7;
 }
 
 message TU {

--- a/scripts/cxx_codegen/reflection_defs.proto
+++ b/scripts/cxx_codegen/reflection_defs.proto
@@ -239,6 +239,15 @@ message Record {
     bool IsDescribedRecord = 19;
 }
 
+message IncludeVisit {
+    string RelativePath = 1;
+    string AbsolutePath = 2;
+    uint32 DirectLineCount = 3;
+    uint32 ExpandedLineCountWithNested = 4;
+    uint32 ExpandedLineCountWithoutNested = 5;
+    repeated IncludeVisit Nested = 6;
+}
+
 message TU {
     repeated Record records = 1;
     repeated Enum enums = 2;
@@ -247,4 +256,5 @@ message TU {
     repeated Include includes = 5;
     string AbsolutePath = 6;
     string Doc = 7;
+    IncludeVisit MainFileIncludeTree = 8;
 }

--- a/scripts/cxx_codegen/reflection_defs.proto
+++ b/scripts/cxx_codegen/reflection_defs.proto
@@ -241,11 +241,14 @@ message Record {
 
 message IncludeVisit {
     string RelativePath = 1;
+    /// normalized absolute path to the included file.
     string AbsolutePath = 2;
-    uint32 DirectLineCount = 3;
-    uint32 ExpandedLineCountWithNested = 4;
-    uint32 ExpandedLineCountWithoutNested = 5;
-    uint32 PhysicalLine = 6;
+    uint32 FileLineCount = 3;
+    /// Direct lines expanded from the included file,
+    /// excluding all nested files.
+    uint32 DirectExpandedLines = 4;
+    /// where in the file include happened
+    uint32 IncludeLocationLine = 6;
     repeated IncludeVisit Nested = 7;
 }
 

--- a/scripts/cxx_codegen/reflection_defs.proto
+++ b/scripts/cxx_codegen/reflection_defs.proto
@@ -246,7 +246,7 @@ message IncludeVisit {
     uint32 FileLineCount = 3;
     /// Direct lines expanded from the included file,
     /// excluding all nested files.
-    uint32 DirectExpandedLines = 4;
+    uint32 UsedLineCount = 4;
     /// where in the file include happened
     uint32 IncludeLocationLine = 6;
     repeated IncludeVisit Nested = 7;

--- a/scripts/py_codegen/py_codegen/refl_read.py
+++ b/scripts/py_codegen/py_codegen/refl_read.py
@@ -20,6 +20,31 @@ from py_scriptutils.script_logging import ExceptionContextNote, log
 
 CAT = __name__
 
+from rich.tree import Tree
+
+
+def include_visit_to_rich_tree(
+    root: pb.IncludeVisit,
+    absolute_prefix: str = "",
+    max_depth: int = 10,
+) -> Tree:
+
+    def build_label(node: pb.IncludeVisit) -> str:
+        return (
+            f"{node.relative_path} ({node.absolute_path.removeprefix(absolute_prefix)}) "
+            f"[dim](line {node.include_location_line}, "
+            f"used {node.used_line_count}/{node.file_line_count})[/dim]")
+
+    def add_children(tree: Tree, node: pb.IncludeVisit, depth: int) -> None:
+        for child in node.nested:
+            branch = tree.add(build_label(child))
+            if depth < max_depth:
+                add_children(branch, child, depth + 1)
+
+    tree = Tree(build_label(root))
+    add_children(tree, root, 0)
+    return tree
+
 
 @beartype
 def conv_proto_default(value: pb.Expr) -> Optional[str]:

--- a/scripts/py_codegen/py_codegen/refl_read.py
+++ b/scripts/py_codegen/py_codegen/refl_read.py
@@ -387,6 +387,7 @@ class ConvTu:
     enums: List[codegen_ir.GenTuEnum] = field(default_factory=list)
     typedefs: List[codegen_ir.GenTuTypedef] = field(default_factory=list)
     includes: List[codegen_ir.GenTuInclude] = field(default_factory=list)
+    main_file_include_tree: Optional[pb.IncludeVisit] = None
     absoluteOriginal: Optional[str] = None
 
     def get_all(self) -> List[codegen_ir.GenTuUnion]:
@@ -537,4 +538,5 @@ def conv_proto_file(path: Path, original: Optional[Path] = None) -> ConvTu:
         typedefs=[conv_proto_typedef(rec, original) for rec in unit.typedefs],
         functions=[conv_proto_function(rec, original) for rec in unit.functions],
         includes=[conv_proto_include(rec, original) for rec in unit.includes],
+        main_file_include_tree=unit.main_file_include_tree,
     )

--- a/scripts/py_repository/py_repository/code_analysis/gen_include_branching_graph.py
+++ b/scripts/py_repository/py_repository/code_analysis/gen_include_branching_graph.py
@@ -66,8 +66,7 @@ def create_include_tree_graph(
             return cumulative_cache[key]
         total = int(v.used_line_count)
         for ch in v.nested:
-            if is_kept(ch):
-                total += cumulative_used(ch)
+            total += cumulative_used(ch)
         cumulative_cache[key] = total
         return total
 
@@ -89,20 +88,38 @@ def create_include_tree_graph(
             "</TR>"
             "</TABLE>")
 
+    def nested_rows_for(
+            v: pb.IncludeVisit
+    ) -> list[tuple[pb.IncludeVisit, int, int, str, int | None]]:
+        rows: list[tuple[pb.IncludeVisit, int, int, str, bool]] = []
+        for ch in v.nested:
+            rows.append((
+                ch,
+                cumulative_used(ch),
+                int(ch.file_line_count),
+                ch.relative_path or ch.absolute_path or "<unknown>",
+                is_kept(ch),
+            ))
+
+        rows.sort(key=lambda item: item[1], reverse=True)
+
+        result: list[tuple[pb.IncludeVisit, int, int, str, int | None]] = []
+        port_index = 0
+        for ch, used, lines, name, kept in rows:
+            if kept:
+                result.append((ch, used, lines, name, port_index))
+                port_index += 1
+            else:
+                result.append((ch, used, lines, name, None))
+
+        return result
+
     def node_label(v: pb.IncludeVisit) -> str:
         title = html.escape(v.relative_path or v.absolute_path or "<root>")
         physical = int(v.file_line_count)
         used_sum = cumulative_used(v)
 
-        children = [ch for ch in v.nested if is_kept(ch)]
-        child_rows = []
-        for ch in children:
-            used = cumulative_used(ch)
-            share = 0.0 if used_sum == 0 else (used / used_sum) * 100.0
-            rel = html.escape(ch.relative_path or ch.absolute_path or "<unknown>")
-            child_rows.append((rel, used, int(ch.file_line_count), share))
-
-        child_rows.sort(key=lambda item: item[1], reverse=True)
+        nested_rows = nested_rows_for(v)
 
         rows = [
             "<TR>",
@@ -123,14 +140,22 @@ def create_include_tree_graph(
             "</TR>",
         ]
 
-        for i, (rel, used, lines, share) in enumerate(child_rows):
+        for ch, used, lines, rel, port_index in nested_rows:
+            share = 0.0 if used_sum == 0 else (used / used_sum) * 100.0
             progress = progress_table_html(share)
+            rel_escaped = html.escape(rel)
+
+            if port_index is None:
+                to_cell = "<TD></TD>"
+            else:
+                to_cell = f'<TD PORT="p{port_index}">→</TD>'
+
             rows.append("<TR>"
-                        f'<TD ALIGN="LEFT">{rel}</TD>'
+                        f'<TD ALIGN="LEFT">{rel_escaped}</TD>'
                         f"<TD>{used}</TD>"
                         f"<TD>{lines}</TD>"
                         f"<TD>{progress}</TD>"
-                        f'<TD PORT="p{i}">→</TD>'
+                        f"{to_cell}"
                         "</TR>")
 
         return ("<<TABLE BORDER=\"0\" CELLBORDER=\"1\" CELLSPACING=\"0\">" +
@@ -178,29 +203,20 @@ def create_include_tree_graph(
         add_vertex_record(v, node_id, parent_id, parent_row_index)
         dot.node(node_id, node_label(v))
 
-        children = [ch for ch in v.nested if is_kept(ch)]
-        child_rows = []
-        for ch in children:
-            child_rows.append((
-                ch,
-                cumulative_used(ch),
-                int(ch.file_line_count),
-                ch.relative_path or ch.absolute_path or "<unknown>",
-            ))
+        for ch, _used, _lines, _name, port_index in nested_rows_for(v):
+            if port_index is None:
+                continue
 
-        child_rows.sort(key=lambda item: item[1], reverse=True)
-
-        for row_index, (ch, _used, _lines, _name) in enumerate(child_rows):
-            child_id = emit(
+            nested_id = emit(
                 ch,
                 parent_id=node_id,
-                parent_row_index=row_index,
+                parent_row_index=port_index,
             )
-            dot.edge(f"{node_id}:p{row_index}:e", child_id)
+            dot.edge(f"{node_id}:p{port_index}:e", nested_id)
             graph.add_edge(
                 node_id,
-                child_id,
-                parent_row_index=row_index,
+                nested_id,
+                parent_row_index=port_index,
             )
 
         return node_id
@@ -291,12 +307,12 @@ def write_include_tree_html(
                         return title ? title.parentElement : null;
                     }}
 
-                    function getEdgeGroup(parentId, childId) {{
+                    function getEdgeGroup(parentId, nestedId) {{
                         const graphRoot = getGraphRootGroup();
                         if (!graphRoot) {{
                             return null;
                         }}
-                        const titleText = `${{parentId}}->${{childId}}`;
+                        const titleText = `${{parentId}}->${{nestedId}}`;
                         const title = Array.from(graphRoot.querySelectorAll('g.edge > title'))
                             .find(el => el.textContent.trim() === titleText);
                         return title ? title.parentElement : null;
@@ -334,7 +350,7 @@ def write_include_tree_html(
 
                     function attachInteractivity() {{
                         for (let i = 0; i < EDGE_NAMES.length; ++i) {{
-                            const [parentId, childId] = EDGE_NAMES[i];
+                            const [parentId, nestedId] = EDGE_NAMES[i];
                             const rowIndex = EDGE_ROWS[i];
                             const arrowText = getArrowCell(parentId, rowIndex);
                             if (!arrowText) {{
@@ -352,11 +368,11 @@ def write_include_tree_html(
                             rect.setAttribute('fill', 'transparent');
                             rect.setAttribute('class', 'include-arrow-hit');
 
-                            rect.addEventListener('click', () => focusNode(childId));
+                            rect.addEventListener('click', () => focusNode(nestedId));
 
-                            arrowText.parentElement.appendChild(rect);
+                            arrowText.parentElement.appendnested(rect);
 
-                            const edgeGroup = getEdgeGroup(parentId, childId);
+                            const edgeGroup = getEdgeGroup(parentId, nestedId);
                             if (edgeGroup) {{
                                 edgeGroup.style.pointerEvents = 'none';
                             }}

--- a/scripts/py_repository/py_repository/code_analysis/gen_include_branching_graph.py
+++ b/scripts/py_repository/py_repository/code_analysis/gen_include_branching_graph.py
@@ -1,0 +1,369 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import html
+from pathlib import Path
+from typing import Literal
+
+from dominate import document
+from dominate.tags import a, body, div, head, meta, script, style
+from dominate.util import raw
+import graphviz
+import igraph as ig
+import py_codegen.proto_lib as pb
+
+
+@dataclass(frozen=True)
+class IncludeTreeNode:
+    visit: pb.IncludeVisit
+    node_id: str
+    path_key: str
+    parent_id: str | None
+    parent_row_index: int | None
+
+
+def create_include_tree_graph(
+    visit: pb.IncludeVisit,
+    *,
+    root_dir: str | Path | None = None,
+) -> tuple[graphviz.Digraph, ig.Graph]:
+    dot = graphviz.Digraph("include_tree")
+    dot.attr("graph", rankdir="LR")
+    dot.attr("node", shape="plain")
+
+    graph = ig.Graph(directed=True)
+    cumulative_cache: dict[int, int] = {}
+    kept_cache: dict[int, bool] = {}
+
+    root_path = Path(root_dir).resolve() if root_dir is not None else None
+
+    def visit_path(v: pb.IncludeVisit) -> Path | None:
+        path = v.absolute_path or v.relative_path
+        if not path:
+            return None
+        return Path(path).resolve()
+
+    def is_kept(v: pb.IncludeVisit) -> bool:
+        key = id(v)
+        if key in kept_cache:
+            return kept_cache[key]
+
+        if root_path is None:
+            result = True
+        else:
+            path = visit_path(v)
+            if path is None:
+                result = False
+            else:
+                result = root_path == path or root_path in path.parents
+
+        kept_cache[key] = result
+        return result
+
+    def cumulative_used(v: pb.IncludeVisit) -> int:
+        key = id(v)
+        if key in cumulative_cache:
+            return cumulative_cache[key]
+        total = int(v.used_line_count)
+        for ch in v.nested:
+            if is_kept(ch):
+                total += cumulative_used(ch)
+        cumulative_cache[key] = total
+        return total
+
+    def progress_table_html(percent: float) -> str:
+        clamped = max(0.0, min(100.0, percent))
+        text = f"{int(round(clamped)):d}%"
+        return (
+            '<TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0">'
+            "<TR>"
+            f'<TD WIDTH="60" ALIGN="RIGHT">{html.escape(text)}</TD>'
+            '<TD WIDTH="120" HEIGHT="10" FIXEDSIZE="TRUE" CELLPADDING="0">'
+            '<TABLE BORDER="0" CELLBORDER="0" CELLSPACING="0" CELLPADDING="0" WIDTH="120">'
+            "<TR>"
+            f'<TD BGCOLOR="#4caf50" WIDTH="{clamped:.2f}%"></TD>'
+            f'<TD BGCOLOR="#e0e0e0" WIDTH="{100.0 - clamped:.2f}%"></TD>'
+            "</TR>"
+            "</TABLE>"
+            "</TD>"
+            "</TR>"
+            "</TABLE>")
+
+    def node_label(v: pb.IncludeVisit) -> str:
+        title = html.escape(v.relative_path or v.absolute_path or "<root>")
+        physical = int(v.file_line_count)
+        used_sum = cumulative_used(v)
+
+        children = [ch for ch in v.nested if is_kept(ch)]
+        child_rows = []
+        for ch in children:
+            used = cumulative_used(ch)
+            share = 0.0 if used_sum == 0 else (used / used_sum) * 100.0
+            rel = html.escape(ch.relative_path or ch.absolute_path or "<unknown>")
+            child_rows.append((rel, used, int(ch.file_line_count), share))
+
+        child_rows.sort(key=lambda item: item[1], reverse=True)
+
+        rows = [
+            "<TR>",
+            f'<TD COLSPAN="4"><B>{title}</B></TD>',
+            '<TD><FONT POINT-SIZE="10">'
+            '<TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0">'
+            f"<TR><TD ALIGN=\"LEFT\">physical</TD><TD>{physical}</TD></TR>"
+            f"<TR><TD ALIGN=\"LEFT\">used sum</TD><TD>{used_sum}</TD></TR>"
+            "</TABLE>"
+            "</FONT></TD>",
+            "</TR>",
+            "<TR>"
+            "<TD><B>include</B></TD>"
+            "<TD><B>used Σ</B></TD>"
+            "<TD><B>lines</B></TD>"
+            "<TD><B>% of used</B></TD>"
+            "<TD><B>to</B></TD>"
+            "</TR>",
+        ]
+
+        for i, (rel, used, lines, share) in enumerate(child_rows):
+            progress = progress_table_html(share)
+            rows.append("<TR>"
+                        f'<TD ALIGN="LEFT">{rel}</TD>'
+                        f"<TD>{used}</TD>"
+                        f"<TD>{lines}</TD>"
+                        f"<TD>{progress}</TD>"
+                        f'<TD PORT="p{i}">→</TD>'
+                        "</TR>")
+
+        return ("<<TABLE BORDER=\"0\" CELLBORDER=\"1\" CELLSPACING=\"0\">" +
+                "".join(rows) + "</TABLE>>")
+
+    seq = 0
+    graph_nodes: list[IncludeTreeNode] = []
+
+    def add_vertex_record(
+        v: pb.IncludeVisit,
+        node_id: str,
+        parent_id: str | None,
+        parent_row_index: int | None,
+    ) -> None:
+        graph.add_vertex(
+            name=node_id,
+            label=v.relative_path or v.absolute_path or "<root>",
+            absolute_path=v.absolute_path or "",
+            relative_path=v.relative_path or "",
+            physical_lines=int(v.file_line_count),
+            used_lines=int(v.used_line_count),
+            cumulative_used_lines=cumulative_used(v),
+            parent_id=parent_id or "",
+            parent_row_index=-1 if parent_row_index is None else parent_row_index,
+        )
+        graph_nodes.append(
+            IncludeTreeNode(
+                visit=v,
+                node_id=node_id,
+                path_key=v.absolute_path or v.relative_path or node_id,
+                parent_id=parent_id,
+                parent_row_index=parent_row_index,
+            ))
+
+    def emit(
+        v: pb.IncludeVisit,
+        *,
+        parent_id: str | None,
+        parent_row_index: int | None,
+    ) -> str:
+        nonlocal seq
+        node_id = f"n{seq}"
+        seq += 1
+
+        add_vertex_record(v, node_id, parent_id, parent_row_index)
+        dot.node(node_id, node_label(v))
+
+        children = [ch for ch in v.nested if is_kept(ch)]
+        child_rows = []
+        for ch in children:
+            child_rows.append((
+                ch,
+                cumulative_used(ch),
+                int(ch.file_line_count),
+                ch.relative_path or ch.absolute_path or "<unknown>",
+            ))
+
+        child_rows.sort(key=lambda item: item[1], reverse=True)
+
+        for row_index, (ch, _used, _lines, _name) in enumerate(child_rows):
+            child_id = emit(
+                ch,
+                parent_id=node_id,
+                parent_row_index=row_index,
+            )
+            dot.edge(f"{node_id}:p{row_index}:e", child_id)
+            graph.add_edge(
+                node_id,
+                child_id,
+                parent_row_index=row_index,
+            )
+
+        return node_id
+
+    emit(visit, parent_id=None, parent_row_index=None)
+    return dot, graph
+
+
+def write_include_tree_html(
+    dot: graphviz.Digraph,
+    graph: ig.Graph,
+    output_html: str | Path,
+    *,
+    root_dir: str | Path | None = None,
+) -> None:
+    svg = dot.pipe(format="svg").decode("utf-8")
+
+    doc = document(title="Include tree")
+    with doc:
+        with head():
+            meta(charset="utf-8")
+            style("""
+                html, body {
+                    margin: 0;
+                    padding: 0;
+                    height: 100%;
+                    font-family: sans-serif;
+                }
+
+                #app {
+                    width: 100%;
+                    height: 100vh;
+                    overflow: auto;
+                    background: #ffffff;
+                }
+
+                #app svg {
+                    width: max-content;
+                    height: auto;
+                    display: block;
+                }
+
+                .include-arrow-hit {
+                    cursor: pointer;
+                }
+
+                .include-focus {
+                    outline: 3px solid #ff9800;
+                    outline-offset: 4px;
+                }
+                """)
+
+        edge_list = graph.get_edgelist()
+        edge_names = [
+            (graph.vs[src]["name"], graph.vs[dst]["name"]) for src, dst in edge_list
+        ]
+        edge_rows = (list(graph.es["parent_row_index"]) if "parent_row_index"
+                     in graph.es.attribute_names() else [-1] * len(edge_list))
+
+        with body():
+            with div(id="app"):
+                raw(svg)
+            script(
+                raw(f"""
+                    const EDGE_DATA = {edge_list};
+                    const EDGE_ROWS = {edge_rows};
+                    const EDGE_NAMES = {edge_names};
+
+                    function getSvgRoot() {{
+                        return document.querySelector('#app svg');
+                    }}
+
+                    function getGraphRootGroup() {{
+                        const svg = getSvgRoot();
+                        if (!svg) {{
+                            return null;
+                        }}
+                        return svg.querySelector('g.graph');
+                    }}
+
+                    function getNodeGroup(nodeId) {{
+                        const graphRoot = getGraphRootGroup();
+                        if (!graphRoot) {{
+                            return null;
+                        }}
+                        const title = Array.from(graphRoot.querySelectorAll('g.node > title'))
+                            .find(el => el.textContent.trim() === nodeId);
+                        return title ? title.parentElement : null;
+                    }}
+
+                    function getEdgeGroup(parentId, childId) {{
+                        const graphRoot = getGraphRootGroup();
+                        if (!graphRoot) {{
+                            return null;
+                        }}
+                        const titleText = `${{parentId}}->${{childId}}`;
+                        const title = Array.from(graphRoot.querySelectorAll('g.edge > title'))
+                            .find(el => el.textContent.trim() === titleText);
+                        return title ? title.parentElement : null;
+                    }}
+
+                    function getArrowCell(parentId, rowIndex) {{
+                        const nodeGroup = getNodeGroup(parentId);
+                        if (!nodeGroup) {{
+                            return null;
+                        }}
+                        const texts = Array.from(nodeGroup.querySelectorAll('text'));
+                        const arrows = texts.filter(el => el.textContent.trim() === '→');
+                        return arrows[rowIndex] || null;
+                    }}
+
+                    function clearFocus() {{
+                        document.querySelectorAll('.include-focus').forEach(el => {{
+                            el.classList.remove('include-focus');
+                        }});
+                    }}
+
+                    function focusNode(nodeId) {{
+                        const nodeGroup = getNodeGroup(nodeId);
+                        if (!nodeGroup) {{
+                            return;
+                        }}
+                        clearFocus();
+                        nodeGroup.classList.add('include-focus');
+                        nodeGroup.scrollIntoView({{
+                            behavior: 'smooth',
+                            block: 'center',
+                            inline: 'center',
+                        }});
+                    }}
+
+                    function attachInteractivity() {{
+                        for (let i = 0; i < EDGE_NAMES.length; ++i) {{
+                            const [parentId, childId] = EDGE_NAMES[i];
+                            const rowIndex = EDGE_ROWS[i];
+                            const arrowText = getArrowCell(parentId, rowIndex);
+                            if (!arrowText) {{
+                                continue;
+                            }}
+
+                            const bbox = arrowText.getBBox();
+                            const svg = getSvgRoot();
+                            const ns = 'http://www.w3.org/2000/svg';
+                            const rect = document.createElementNS(ns, 'rect');
+                            rect.setAttribute('x', String(bbox.x - 4));
+                            rect.setAttribute('y', String(bbox.y - 2));
+                            rect.setAttribute('width', String(bbox.width + 8));
+                            rect.setAttribute('height', String(bbox.height + 4));
+                            rect.setAttribute('fill', 'transparent');
+                            rect.setAttribute('class', 'include-arrow-hit');
+
+                            rect.addEventListener('click', () => focusNode(childId));
+
+                            arrowText.parentElement.appendChild(rect);
+
+                            const edgeGroup = getEdgeGroup(parentId, childId);
+                            if (edgeGroup) {{
+                                edgeGroup.style.pointerEvents = 'none';
+                            }}
+                        }}
+                    }}
+
+                    window.addEventListener('load', attachInteractivity);
+                    """))
+
+    Path(output_html).write_text(doc.render(), encoding="utf-8")

--- a/scripts/py_repository/py_repository/code_analysis/gen_include_branching_graph.py
+++ b/scripts/py_repository/py_repository/code_analysis/gen_include_branching_graph.py
@@ -88,6 +88,17 @@ def create_include_tree_graph(
             "</TR>"
             "</TABLE>")
 
+    visible_subtree_cache: dict[int, bool] = {}
+
+    def has_visible_subtree(v: pb.IncludeVisit) -> bool:
+        key = id(v)
+        if key in visible_subtree_cache:
+            return visible_subtree_cache[key]
+
+        result = is_kept(v) or any(has_visible_subtree(ch) for ch in v.nested)
+        visible_subtree_cache[key] = result
+        return result
+
     def nested_rows_for(
             v: pb.IncludeVisit
     ) -> list[tuple[pb.IncludeVisit, int, int, str, int | None]]:
@@ -98,15 +109,15 @@ def create_include_tree_graph(
                 cumulative_used(ch),
                 int(ch.file_line_count),
                 ch.relative_path or ch.absolute_path or "<unknown>",
-                is_kept(ch),
+                has_visible_subtree(ch),
             ))
 
         rows.sort(key=lambda item: item[1], reverse=True)
 
         result: list[tuple[pb.IncludeVisit, int, int, str, int | None]] = []
         port_index = 0
-        for ch, used, lines, name, kept in rows:
-            if kept:
+        for ch, used, lines, name, has_visible in rows:
+            if has_visible:
                 result.append((ch, used, lines, name, port_index))
                 port_index += 1
             else:
@@ -195,191 +206,40 @@ def create_include_tree_graph(
         *,
         parent_id: str | None,
         parent_row_index: int | None,
-    ) -> str:
+    ) -> tuple[str, list[str]]:
         nonlocal seq
         node_id = f"n{seq}"
         seq += 1
 
         add_vertex_record(v, node_id, parent_id, parent_row_index)
-        dot.node(node_id, node_label(v))
+
+        visible = is_kept(v)
+        if visible:
+            dot.node(node_id, node_label(v))
+
+        visible_roots: list[str] = [node_id] if visible else []
 
         for ch, _used, _lines, _name, port_index in nested_rows_for(v):
-            if port_index is None:
-                continue
-
-            nested_id = emit(
+            child_id, child_visible_roots = emit(
                 ch,
                 parent_id=node_id,
                 parent_row_index=port_index,
             )
-            dot.edge(f"{node_id}:p{port_index}:e", nested_id)
+
             graph.add_edge(
                 node_id,
-                nested_id,
-                parent_row_index=port_index,
+                child_id,
+                parent_row_index=-1 if port_index is None else port_index,
             )
 
-        return node_id
+            if visible and port_index is not None:
+                for child_visible_id in child_visible_roots:
+                    dot.edge(f"{node_id}:p{port_index}:e", child_visible_id)
 
-    emit(visit, parent_id=None, parent_row_index=None)
+            if not visible:
+                visible_roots.extend(child_visible_roots)
+
+        return node_id, visible_roots
+
+    _root_id, _visible_roots = emit(visit, parent_id=None, parent_row_index=None)
     return dot, graph
-
-
-def write_include_tree_html(
-    dot: graphviz.Digraph,
-    graph: ig.Graph,
-    output_html: str | Path,
-    *,
-    root_dir: str | Path | None = None,
-) -> None:
-    svg = dot.pipe(format="svg").decode("utf-8")
-
-    doc = document(title="Include tree")
-    with doc:
-        with head():
-            meta(charset="utf-8")
-            style("""
-                html, body {
-                    margin: 0;
-                    padding: 0;
-                    height: 100%;
-                    font-family: sans-serif;
-                }
-
-                #app {
-                    width: 100%;
-                    height: 100vh;
-                    overflow: auto;
-                    background: #ffffff;
-                }
-
-                #app svg {
-                    width: max-content;
-                    height: auto;
-                    display: block;
-                }
-
-                .include-arrow-hit {
-                    cursor: pointer;
-                }
-
-                .include-focus {
-                    outline: 3px solid #ff9800;
-                    outline-offset: 4px;
-                }
-                """)
-
-        edge_list = graph.get_edgelist()
-        edge_names = [
-            (graph.vs[src]["name"], graph.vs[dst]["name"]) for src, dst in edge_list
-        ]
-        edge_rows = (list(graph.es["parent_row_index"]) if "parent_row_index"
-                     in graph.es.attribute_names() else [-1] * len(edge_list))
-
-        with body():
-            with div(id="app"):
-                raw(svg)
-            script(
-                raw(f"""
-                    const EDGE_DATA = {edge_list};
-                    const EDGE_ROWS = {edge_rows};
-                    const EDGE_NAMES = {edge_names};
-
-                    function getSvgRoot() {{
-                        return document.querySelector('#app svg');
-                    }}
-
-                    function getGraphRootGroup() {{
-                        const svg = getSvgRoot();
-                        if (!svg) {{
-                            return null;
-                        }}
-                        return svg.querySelector('g.graph');
-                    }}
-
-                    function getNodeGroup(nodeId) {{
-                        const graphRoot = getGraphRootGroup();
-                        if (!graphRoot) {{
-                            return null;
-                        }}
-                        const title = Array.from(graphRoot.querySelectorAll('g.node > title'))
-                            .find(el => el.textContent.trim() === nodeId);
-                        return title ? title.parentElement : null;
-                    }}
-
-                    function getEdgeGroup(parentId, nestedId) {{
-                        const graphRoot = getGraphRootGroup();
-                        if (!graphRoot) {{
-                            return null;
-                        }}
-                        const titleText = `${{parentId}}->${{nestedId}}`;
-                        const title = Array.from(graphRoot.querySelectorAll('g.edge > title'))
-                            .find(el => el.textContent.trim() === titleText);
-                        return title ? title.parentElement : null;
-                    }}
-
-                    function getArrowCell(parentId, rowIndex) {{
-                        const nodeGroup = getNodeGroup(parentId);
-                        if (!nodeGroup) {{
-                            return null;
-                        }}
-                        const texts = Array.from(nodeGroup.querySelectorAll('text'));
-                        const arrows = texts.filter(el => el.textContent.trim() === '→');
-                        return arrows[rowIndex] || null;
-                    }}
-
-                    function clearFocus() {{
-                        document.querySelectorAll('.include-focus').forEach(el => {{
-                            el.classList.remove('include-focus');
-                        }});
-                    }}
-
-                    function focusNode(nodeId) {{
-                        const nodeGroup = getNodeGroup(nodeId);
-                        if (!nodeGroup) {{
-                            return;
-                        }}
-                        clearFocus();
-                        nodeGroup.classList.add('include-focus');
-                        nodeGroup.scrollIntoView({{
-                            behavior: 'smooth',
-                            block: 'center',
-                            inline: 'center',
-                        }});
-                    }}
-
-                    function attachInteractivity() {{
-                        for (let i = 0; i < EDGE_NAMES.length; ++i) {{
-                            const [parentId, nestedId] = EDGE_NAMES[i];
-                            const rowIndex = EDGE_ROWS[i];
-                            const arrowText = getArrowCell(parentId, rowIndex);
-                            if (!arrowText) {{
-                                continue;
-                            }}
-
-                            const bbox = arrowText.getBBox();
-                            const svg = getSvgRoot();
-                            const ns = 'http://www.w3.org/2000/svg';
-                            const rect = document.createElementNS(ns, 'rect');
-                            rect.setAttribute('x', String(bbox.x - 4));
-                            rect.setAttribute('y', String(bbox.y - 2));
-                            rect.setAttribute('width', String(bbox.width + 8));
-                            rect.setAttribute('height', String(bbox.height + 4));
-                            rect.setAttribute('fill', 'transparent');
-                            rect.setAttribute('class', 'include-arrow-hit');
-
-                            rect.addEventListener('click', () => focusNode(nestedId));
-
-                            arrowText.parentElement.appendnested(rect);
-
-                            const edgeGroup = getEdgeGroup(parentId, nestedId);
-                            if (edgeGroup) {{
-                                edgeGroup.style.pointerEvents = 'none';
-                            }}
-                        }}
-                    }}
-
-                    window.addEventListener('load', attachInteractivity);
-                    """))
-
-    Path(output_html).write_text(doc.render(), encoding="utf-8")

--- a/scripts/py_repository/py_repository/code_analysis/gen_include_graph.py
+++ b/scripts/py_repository/py_repository/code_analysis/gen_include_graph.py
@@ -14,7 +14,7 @@ import igraph
 from py_ci.data_build import get_deps_install_config
 from py_codegen.codegen_ir import GenTuInclude, QualType, QualTypeKind
 import py_codegen.proto_lib as pb
-from py_codegen.refl_read import conv_proto_file, ConvTu
+from py_codegen.refl_read import conv_proto_file, ConvTu, include_visit_to_rich_tree
 from py_codegen.refl_wrapper_graph import (
     get_declared_types_rec,
     get_used_types_rec,
@@ -33,6 +33,7 @@ from py_repository.repo_tasks.common import (
     get_workflow_out,
 )
 from py_repository.repo_tasks.workflow_utils import TaskContext
+from py_scriptutils.rich_utils import render_rich
 from py_scriptutils.script_logging import log
 from pydantic import BaseModel, Field
 
@@ -502,13 +503,22 @@ def gen_include_graph(
                 tu.main_file_include_tree,
                 root_dir=get_script_root(ctx).joinpath("src"),
             )
+
             outfile = get_workflow_out(
                 ctx,
                 f"include_graph/branching_include_graphs/{Path(tu.absoluteOriginal).name}_branch"
             )
 
-            gg_branch.render(str(outfile), format="png")
-            log().info(f"wrote {outfile}.png")
+            Path(str(outfile) + ".txt").write_text(
+                render_rich(
+                    include_visit_to_rich_tree(tu.main_file_include_tree,),
+                    color=False,
+                ).replace("│   ", "    ").replace("├── ", "    ").replace("└── ", "    "))
+
+            # FIXME: The render operation reports multiple instances of teh labels being too large for the
+            # cells in the HTML graph.
+            gg_branch.render(str(outfile), format="png", quiet=True)
+            log().info(f"wrote {outfile}.png {outfile}.txt")
 
         if tu.absoluteOriginal.endswith("hpp"):
             used_types: List[QualType] = list()

--- a/scripts/py_repository/py_repository/code_analysis/gen_include_graph.py
+++ b/scripts/py_repository/py_repository/code_analysis/gen_include_graph.py
@@ -476,7 +476,7 @@ def gen_include_graph(
     ok_files: List[Path] = []
     files = list(get_script_root(ctx, "src").rglob("*.?pp"))
 
-    files = files[20:40]
+    # files = files[20:40]
 
     with ThreadPoolExecutor(max_workers=6) as executor:
         futures = [

--- a/scripts/py_repository/py_repository/code_analysis/gen_include_graph.py
+++ b/scripts/py_repository/py_repository/code_analysis/gen_include_graph.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from concurrent.futures import as_completed, ThreadPoolExecutor
+from concurrent.futures import as_completed, ProcessPoolExecutor, ThreadPoolExecutor
 from dataclasses import dataclass, field
 import html
 from pathlib import Path
@@ -452,32 +452,13 @@ class TraceFile(BaseModel, extra="forbid"):
 
 
 @beartype
-def gen_include_graph(
+def collect_reflection_files(
     ctx: TaskContext,
+    files: List[Path],
     compile_commands: Path,
     header_commands: Path,
-) -> None:
-    header_compdb_content = run_command(
-        ctx,
-        "uv",
-        [
-            "run",
-            "compdb",
-            "-p",
-            compile_commands.parent,
-            "list",
-        ],
-        capture=True,
-    )
-
-    ctx_write_text(ctx, header_commands, header_compdb_content[1])
-    log(CAT).info(f"Wrote extended compilation database to {header_commands}")
-
+) -> List[Path]:
     ok_files: List[Path] = []
-    files = list(get_script_root(ctx, "src").rglob("*.?pp"))
-
-    # files = files[20:40]
-
     with ThreadPoolExecutor(max_workers=6) as executor:
         futures = [
             executor.submit(process_reflection_file, ctx, file, compile_commands,
@@ -489,62 +470,76 @@ def gen_include_graph(
             if result is not None:
                 ok_files.append(result)
 
-    conv_tus: List[ReflectionFile] = []
+    return ok_files
 
-    for f in ok_files:
-        tu = conv_proto_file(f)
-        tu_unit = pb.Tu.FromString(f.read_bytes())
-        tu_json = f.with_suffix(".json")
-        tu_json.write_text(tu_unit.to_json(indent=2))
 
-        assert tu.absoluteOriginal
-        if tu.main_file_include_tree:
-            gg_branch, gg_igraph = gen_include_branching_graph.create_include_tree_graph(
-                tu.main_file_include_tree,
-                root_dir=get_script_root(ctx).joinpath("src"),
-            )
+@beartype
+def gen_branching_include_graph(ctx: TaskContext, f: Path) -> None:
+    tu = conv_proto_file(f)
+    tu_unit = pb.Tu.FromString(f.read_bytes())
+    tu_json = f.with_suffix(".json")
+    tu_json.write_text(tu_unit.to_json(indent=2))
 
-            outfile = get_workflow_out(
-                ctx,
-                f"include_graph/branching_include_graphs/{Path(tu.absoluteOriginal).name}_branch"
-            )
+    assert tu.absoluteOriginal
+    if tu.main_file_include_tree:
+        gg_branch, gg_igraph = gen_include_branching_graph.create_include_tree_graph(
+            tu.main_file_include_tree,
+            root_dir=get_script_root(ctx).joinpath("src"),
+        )
 
-            Path(str(outfile) + ".txt").write_text(
-                render_rich(
-                    include_visit_to_rich_tree(tu.main_file_include_tree,),
-                    color=False,
-                ).replace("│   ", "    ").replace("├── ", "    ").replace("└── ", "    "))
+        outfile = get_workflow_out(
+            ctx,
+            f"include_graph/branching_include_graphs/{Path(tu.absoluteOriginal).name}_branch"
+        )
 
-            # FIXME: The render operation reports multiple instances of teh labels being too large for the
-            # cells in the HTML graph.
-            gg_branch.render(str(outfile), format="png", quiet=True)
-            log().info(f"wrote {outfile}.png {outfile}.txt")
+        Path(str(outfile) + ".txt").write_text(
+            render_rich(
+                include_visit_to_rich_tree(tu.main_file_include_tree,),
+                color=False,
+            ).replace("│   ", "    ").replace("├── ", "    ").replace("└── ", "    "))
 
-        if tu.absoluteOriginal.endswith("hpp"):
-            used_types: List[QualType] = list()
-            used_types_set = set()
-            for t in get_used_types_rec(tu, expanded_use=False):
-                thash = hash_qual_type(t, with_namespace=True)
-                if thash in used_types_set:
-                    continue
-                else:
-                    used_types_set.add(thash)
+        # FIXME: The render operation reports multiple instances of teh labels being too large for the
+        # cells in the HTML graph.
+        gg_branch.render(str(outfile), format="png", quiet=True)
+        log().info(f"wrote {outfile}.png {outfile}.txt")
 
-                if "describe" not in t.flatQualName():
-                    used_types.append(t)
 
-            declared_types = get_declared_types_rec(
-                tu,
-                expanded_use=False,
-            )
+@beartype
+def conv_reflection_file(f: Path) -> Optional[ReflectionFile]:
+    tu = conv_proto_file(f)
+    assert tu.absoluteOriginal
+    if not tu.absoluteOriginal.endswith("hpp"):
+        return None
 
-            conv_tus.append(
-                ReflectionFile(
-                    tu=tu,
-                    declaredTypes=declared_types,
-                    usedTypes=used_types,
-                ))
+    used_types: List[QualType] = list()
+    used_types_set = set()
+    for t in get_used_types_rec(tu, expanded_use=False):
+        thash = hash_qual_type(t, with_namespace=True)
+        if thash in used_types_set:
+            continue
+        else:
+            used_types_set.add(thash)
 
+        if "describe" not in t.flatQualName():
+            used_types.append(t)
+
+    declared_types = get_declared_types_rec(
+        tu,
+        expanded_use=False,
+    )
+
+    return ReflectionFile(
+        tu=tu,
+        declaredTypes=declared_types,
+        usedTypes=used_types,
+    )
+
+
+@beartype
+def gen_final_include_graph(
+    ctx: TaskContext,
+    conv_tus: List[ReflectionFile],
+) -> None:
     igraph_tus = create_include_graph(ctx, conv_tus)
 
     graphviz_tus = igraph_to_graphviz(igraph_tus)
@@ -569,3 +564,45 @@ def gen_include_graph(
     # generate_transitive_subgraph("_base")
     igraph_tus = remove_redundant_edges(igraph_tus)
     generate_transitive_subgraph("_reduced")
+
+
+@beartype
+def gen_include_graph(
+    ctx: TaskContext,
+    compile_commands: Path,
+    header_commands: Path,
+) -> None:
+    header_compdb_content = run_command(
+        ctx,
+        "uv",
+        [
+            "run",
+            "compdb",
+            "-p",
+            compile_commands.parent,
+            "list",
+        ],
+        capture=True,
+    )
+
+    ctx_write_text(ctx, header_commands, header_compdb_content[1])
+    log(CAT).info(f"Wrote extended compilation database to {header_commands}")
+
+    files = list(get_script_root(ctx, "src").rglob("*.?pp"))
+
+    # files = files[20:40]
+
+    ok_files = collect_reflection_files(ctx, files, compile_commands, header_commands)
+
+    with ProcessPoolExecutor(max_workers=20) as executor:
+        futures = [executor.submit(gen_branching_include_graph, ctx, f) for f in ok_files]
+        for future in as_completed(futures):
+            future.result()
+
+    conv_tus: List[ReflectionFile] = []
+    with ThreadPoolExecutor(max_workers=12) as executor:
+        for result in executor.map(conv_reflection_file, ok_files):
+            if result is not None:
+                conv_tus.append(result)
+
+    gen_final_include_graph(ctx, conv_tus)

--- a/scripts/py_repository/py_repository/code_analysis/gen_include_graph.py
+++ b/scripts/py_repository/py_repository/code_analysis/gen_include_graph.py
@@ -1,10 +1,11 @@
 from collections import defaultdict
 from concurrent.futures import as_completed, ThreadPoolExecutor
 from dataclasses import dataclass, field
+import html
 from pathlib import Path
 
 from beartype import beartype
-from beartype.typing import Any, Dict, List, Optional, Tuple
+from beartype.typing import Any, Dict, List, Literal, Optional, Tuple
 import dominate
 import dominate.tags
 import dominate.util
@@ -426,6 +427,79 @@ def create_project_file_subgraphs(
     return result
 
 
+def create_include_dag(visit: pb.IncludeVisit,
+                       visual_mode: Literal["tree", "dag"]) -> graphviz.Digraph:
+    if visual_mode not in ("tree", "dag"):
+        raise ValueError(f"Unsupported visual_mode: {visual_mode}")
+
+    dot = graphviz.Digraph("include_dag")
+    dot.attr("graph", rankdir="LR")
+    dot.attr("node", shape="plain")
+
+    cumulative_cache: dict[int, int] = {}
+
+    def cumulative_used(v: pb.IncludeVisit) -> int:
+        key = id(v)
+        if key in cumulative_cache:
+            return cumulative_cache[key]
+        total = int(v.used_line_count) + sum(cumulative_used(ch) for ch in v.nested)
+        cumulative_cache[key] = total
+        return total
+
+    def node_label(v: pb.IncludeVisit) -> str:
+        title = html.escape(v.relative_path or v.absolute_path or "<root>")
+        rows = [
+            f'<TR><TD COLSPAN="4"><B>{title}</B></TD></TR>',
+            "<TR><TD><B>include</B></TD><TD><B>used Σ</B></TD><TD><B>lines</B></TD><TD><B>to</B></TD></TR>",
+        ]
+
+        for i, ch in enumerate(v.nested):
+            rel = html.escape(ch.relative_path or ch.absolute_path)
+            used_sum = cumulative_used(ch)
+            lines = int(ch.file_line_count)
+            rows.append(f'<TR>'
+                        f"<TD ALIGN=\"LEFT\">{rel}</TD>"
+                        f"<TD>{used_sum}</TD>"
+                        f"<TD>{lines}</TD>"
+                        f'<TD PORT="p{i}">→</TD>'
+                        f"</TR>")
+
+        return ("<<TABLE BORDER=\"0\" CELLBORDER=\"1\" CELLSPACING=\"0\">" +
+                "".join(rows) + "</TABLE>>")
+
+    seq = 0
+    dag_ids: dict[str, str] = {}
+    emitted: set[str] = set()
+
+    def get_node_id(v: pb.IncludeVisit) -> str:
+        nonlocal seq
+        if visual_mode == "tree":
+            nid = f"n{seq}"
+            seq += 1
+            return nid
+
+        key = v.absolute_path or v.relative_path
+        if key not in dag_ids:
+            dag_ids[key] = f"n{len(dag_ids)}"
+        return dag_ids[key]
+
+    def emit(v: pb.IncludeVisit, nid: str) -> None:
+        if visual_mode == "dag" and nid in emitted:
+            return
+
+        dot.node(nid, node_label(v))
+        emitted.add(nid)
+
+        for i, ch in enumerate(v.nested):
+            child_id = get_node_id(ch)
+            dot.edge(f"{nid}:p{i}:e", child_id)
+            emit(ch, child_id)
+
+    root_id = get_node_id(visit)
+    emit(visit, root_id)
+    return dot
+
+
 class TraceEvent(BaseModel, extra="forbid"):
     pid: int = 0
     tid: int = 0
@@ -494,6 +568,18 @@ def gen_include_graph(
         tu_unit = pb.Tu.FromString(f.read_bytes())
         tu_json = f.with_suffix(".json")
         tu_json.write_text(tu_unit.to_json(indent=2))
+
+        assert tu.absoluteOriginal
+        if tu.main_file_include_tree:
+            gg_branch = create_include_dag(tu.main_file_include_tree, "dag")
+            outfile = get_workflow_out(
+                ctx,
+                f"include_graph/branching_include_graphs/{Path(tu.absoluteOriginal).name}_branch"
+            )
+
+            gg_branch.render(str(outfile), format="png")
+            log().info(f"wrote {outfile}.png")
+
         if tu.absoluteOriginal.endswith("hpp"):
             used_types: List[QualType] = list()
             used_types_set = set()

--- a/scripts/py_repository/py_repository/code_analysis/gen_include_graph.py
+++ b/scripts/py_repository/py_repository/code_analysis/gen_include_graph.py
@@ -507,11 +507,8 @@ def gen_include_graph(
                 f"include_graph/branching_include_graphs/{Path(tu.absoluteOriginal).name}_branch"
             )
 
-            gen_include_branching_graph.write_include_tree_html(
-                gg_branch, gg_igraph, output_html=outfile.with_suffix(".html"))
-
             gg_branch.render(str(outfile), format="png")
-            log().info(f"wrote {outfile}.png {outfile}.html")
+            log().info(f"wrote {outfile}.png")
 
         if tu.absoluteOriginal.endswith("hpp"):
             used_types: List[QualType] = list()

--- a/scripts/py_repository/py_repository/code_analysis/gen_include_graph.py
+++ b/scripts/py_repository/py_repository/code_analysis/gen_include_graph.py
@@ -474,7 +474,7 @@ def gen_include_graph(
     ok_files: List[Path] = []
     files = list(get_script_root(ctx, "src").rglob("*.?pp"))
 
-    # files = files[:10]
+    files = files[20:40]
 
     with ThreadPoolExecutor(max_workers=6) as executor:
         futures = [
@@ -536,7 +536,7 @@ def gen_include_graph(
                         ctx, f"include_graph/individual_include_graphs/{incd.name}").
                     with_suffix("")) + suffix)
 
-            log(CAT).info(f"Partial group graph in {sub_file}")
+            log(CAT).info(f"Partial group graph in {sub_file}.png")
             ensure_existing_dir(ctx, sub_file.parent)
             igraph_to_graphviz(subgraph, target=sub_vertex).render(sub_file, format="png")
 

--- a/scripts/py_repository/py_repository/code_analysis/gen_include_graph.py
+++ b/scripts/py_repository/py_repository/code_analysis/gen_include_graph.py
@@ -20,7 +20,7 @@ from py_codegen.refl_wrapper_graph import (
     get_used_types_rec,
     hash_qual_type,
 )
-from py_repository.code_analysis import gen_coverage_cookies
+from py_repository.code_analysis import gen_coverage_cookies, gen_include_branching_graph
 from py_repository.repo_tasks.command_execution import (
     run_command,
     run_command_with_json_args,
@@ -427,79 +427,6 @@ def create_project_file_subgraphs(
     return result
 
 
-def create_include_dag(visit: pb.IncludeVisit,
-                       visual_mode: Literal["tree", "dag"]) -> graphviz.Digraph:
-    if visual_mode not in ("tree", "dag"):
-        raise ValueError(f"Unsupported visual_mode: {visual_mode}")
-
-    dot = graphviz.Digraph("include_dag")
-    dot.attr("graph", rankdir="LR")
-    dot.attr("node", shape="plain")
-
-    cumulative_cache: dict[int, int] = {}
-
-    def cumulative_used(v: pb.IncludeVisit) -> int:
-        key = id(v)
-        if key in cumulative_cache:
-            return cumulative_cache[key]
-        total = int(v.used_line_count) + sum(cumulative_used(ch) for ch in v.nested)
-        cumulative_cache[key] = total
-        return total
-
-    def node_label(v: pb.IncludeVisit) -> str:
-        title = html.escape(v.relative_path or v.absolute_path or "<root>")
-        rows = [
-            f'<TR><TD COLSPAN="4"><B>{title}</B></TD></TR>',
-            "<TR><TD><B>include</B></TD><TD><B>used Σ</B></TD><TD><B>lines</B></TD><TD><B>to</B></TD></TR>",
-        ]
-
-        for i, ch in enumerate(v.nested):
-            rel = html.escape(ch.relative_path or ch.absolute_path)
-            used_sum = cumulative_used(ch)
-            lines = int(ch.file_line_count)
-            rows.append(f'<TR>'
-                        f"<TD ALIGN=\"LEFT\">{rel}</TD>"
-                        f"<TD>{used_sum}</TD>"
-                        f"<TD>{lines}</TD>"
-                        f'<TD PORT="p{i}">→</TD>'
-                        f"</TR>")
-
-        return ("<<TABLE BORDER=\"0\" CELLBORDER=\"1\" CELLSPACING=\"0\">" +
-                "".join(rows) + "</TABLE>>")
-
-    seq = 0
-    dag_ids: dict[str, str] = {}
-    emitted: set[str] = set()
-
-    def get_node_id(v: pb.IncludeVisit) -> str:
-        nonlocal seq
-        if visual_mode == "tree":
-            nid = f"n{seq}"
-            seq += 1
-            return nid
-
-        key = v.absolute_path or v.relative_path
-        if key not in dag_ids:
-            dag_ids[key] = f"n{len(dag_ids)}"
-        return dag_ids[key]
-
-    def emit(v: pb.IncludeVisit, nid: str) -> None:
-        if visual_mode == "dag" and nid in emitted:
-            return
-
-        dot.node(nid, node_label(v))
-        emitted.add(nid)
-
-        for i, ch in enumerate(v.nested):
-            child_id = get_node_id(ch)
-            dot.edge(f"{nid}:p{i}:e", child_id)
-            emit(ch, child_id)
-
-    root_id = get_node_id(visit)
-    emit(visit, root_id)
-    return dot
-
-
 class TraceEvent(BaseModel, extra="forbid"):
     pid: int = 0
     tid: int = 0
@@ -571,14 +498,20 @@ def gen_include_graph(
 
         assert tu.absoluteOriginal
         if tu.main_file_include_tree:
-            gg_branch = create_include_dag(tu.main_file_include_tree, "dag")
+            gg_branch, gg_igraph = gen_include_branching_graph.create_include_tree_graph(
+                tu.main_file_include_tree,
+                root_dir=get_script_root(ctx).joinpath("src"),
+            )
             outfile = get_workflow_out(
                 ctx,
                 f"include_graph/branching_include_graphs/{Path(tu.absoluteOriginal).name}_branch"
             )
 
+            gen_include_branching_graph.write_include_tree_html(
+                gg_branch, gg_igraph, output_html=outfile.with_suffix(".html"))
+
             gg_branch.render(str(outfile), format="png")
-            log().info(f"wrote {outfile}.png")
+            log().info(f"wrote {outfile}.png {outfile}.html")
 
         if tu.absoluteOriginal.endswith("hpp"):
             used_types: List[QualType] = list()

--- a/scripts/py_repository/py_repository/repo_tasks/haxorg_conf.json
+++ b/scripts/py_repository/py_repository/repo_tasks/haxorg_conf.json
@@ -15,6 +15,7 @@
     // "use_valgrind": true,
     // "valgrind_suppression": "/home/haxscramper/tmp/pyton_suppression.supp",
     "extra_pytest_args"     : [
+      // "tests/python/refl/test_include_reflection.py",
       // "tests/python/repo/test_code_forensics.py",
       // "tests/python/repo/test_code_forensics.py::test_infer_current_dir_subset"
       // "tests/python/test_execution_tracker.py"

--- a/tests/python/refl/refl_test_driver.py
+++ b/tests/python/refl/refl_test_driver.py
@@ -23,6 +23,7 @@ from py_codegen.codegen_ir import (
     GenTuUnion,
     GenTypeMap,
 )
+import py_codegen.proto_lib as pb
 import py_codegen.refl_extract as ex
 from py_codegen.refl_read import ConvTu, QualType
 from py_codegen.refl_wrapper_graph import GenGraph, TuWrap
@@ -183,6 +184,7 @@ def run_reflection_tool_provider(
 
     for file, content in text.items():
         full = Path(code_dir).joinpath(file)
+        full.parent.mkdir(exist_ok=True, parents=True)
         if full.exists():
             if full.read_text() != content:
                 full.write_text(content)
@@ -230,6 +232,27 @@ def get_struct(
     ).wraps[0].tu
     assert len(tu.structs) == 1
     return tu.structs[0]
+
+
+def get_include_tree(
+    text: Union[str, Dict[str, str]],
+    stable_test_dir: Path,
+    main_file_suffix: str,
+    code_dir_override: Optional[Path] = None,
+    **kwargs: Any,
+) -> pb.IncludeVisit:
+    code_dir = stable_test_dir
+    tus = run_reflection_tool_provider(
+        text,
+        code_dir_override or Path(code_dir),
+        output_dir=stable_test_dir,
+        **kwargs,
+    ).wraps
+    tu = next(it for it in tus
+              if it.tu.main_file_include_tree.absolute_path.endswith(main_file_suffix))
+
+    assert tu.tu.main_file_include_tree
+    return tu.tu.main_file_include_tree
 
 
 @beartype

--- a/tests/python/refl/test_include_reflection.py
+++ b/tests/python/refl/test_include_reflection.py
@@ -1,0 +1,208 @@
+import itertools
+from pathlib import Path
+from tempfile import gettempdir
+
+from more_itertools import first_true
+import py_codegen.proto_lib as pb
+from py_codegen.refl_read import include_visit_to_rich_tree
+from py_scriptutils.rich_utils import render_rich
+from py_scriptutils.script_logging import log
+import pytest
+
+
+@pytest.mark.test_release
+def test_standard_library_include(stable_test_dir: Path) -> None:
+    import tests.python.refl.refl_test_driver as refl_test_driver
+    incl: pb.IncludeVisit = refl_test_driver.get_include_tree(
+        {
+            "a.hpp": '#include "b.hpp"',
+            "b.hpp": '#include "c.hpp"',
+            "c.hpp": "",
+        },
+        main_file_suffix="a.hpp",
+        stable_test_dir=stable_test_dir,
+    )
+
+    log().info("\n" + render_rich(
+        include_visit_to_rich_tree(
+            incl,
+            absolute_prefix=str(stable_test_dir),
+        )))
+
+    assert incl.absolute_path.endswith("a.hpp")
+    assert incl.nested[0].relative_path == "b.hpp"
+    assert incl.nested[0].include_location_line == 1
+    assert incl.nested[0].nested[0].relative_path == "c.hpp"
+
+
+@pytest.mark.test_release
+def test_include_standard_library_header(stable_test_dir: Path) -> None:
+    import tests.python.refl.refl_test_driver as refl_test_driver
+
+    incl: pb.IncludeVisit = refl_test_driver.get_include_tree(
+        {"main.hpp": "#include <vector>"},
+        main_file_suffix="main.hpp",
+        stable_test_dir=stable_test_dir,
+    )
+
+    std = incl.nested[0]
+    assert incl.absolute_path.endswith("main.hpp")
+    assert std.relative_path == "vector"
+    assert std.include_location_line == 1
+    assert std.absolute_path
+    assert 0 < std.file_line_count
+    assert 0 < std.used_line_count <= std.file_line_count
+
+
+@pytest.mark.test_release
+def test_nested_directory_inclusion(stable_test_dir: Path) -> None:
+    import tests.python.refl.refl_test_driver as refl_test_driver
+
+    incl: pb.IncludeVisit = refl_test_driver.get_include_tree(
+        {
+            "a.hpp": '#include "inc/one/b.hpp"',
+            "inc/one/b.hpp": '#include "../two/c.hpp"\nint b;',
+            "inc/two/c.hpp": "int c;",
+        },
+        main_file_suffix="a.hpp",
+        stable_test_dir=stable_test_dir,
+    )
+
+    b = incl.nested[0]
+    c = b.nested[0]
+
+    assert b.relative_path == "inc/one/b.hpp"
+    assert b.absolute_path.endswith("inc/one/b.hpp")
+    assert b.include_location_line == 1
+    assert b.file_line_count == 2
+    assert b.used_line_count == 2
+
+    assert c.relative_path == "../two/c.hpp"
+    assert c.absolute_path.endswith("inc/two/c.hpp")
+    assert c.include_location_line == 1
+    assert c.file_line_count == 1
+    assert c.used_line_count == 1
+
+
+@pytest.mark.test_release
+def test_duplicate_header_names_in_different_directories(stable_test_dir: Path) -> None:
+    import tests.python.refl.refl_test_driver as refl_test_driver
+
+    incl: pb.IncludeVisit = refl_test_driver.get_include_tree(
+        {
+            "main.hpp": '#include "x/common.hpp"\n#include "y/common.hpp"',
+            "x/common.hpp": "int x;",
+            "y/common.hpp": "int y;",
+        },
+        main_file_suffix="main.hpp",
+        stable_test_dir=stable_test_dir,
+    )
+
+    first = incl.nested[0]
+    second = incl.nested[1]
+
+    assert first.relative_path == "x/common.hpp"
+    assert first.absolute_path.endswith("x/common.hpp")
+    assert first.include_location_line == 1
+    assert first.file_line_count == 1
+    assert first.used_line_count == 1
+
+    assert second.relative_path == "y/common.hpp"
+    assert second.absolute_path.endswith("y/common.hpp")
+    assert second.include_location_line == 2
+    assert second.file_line_count == 1
+    assert second.used_line_count == 1
+
+    assert first.absolute_path != second.absolute_path
+
+
+@pytest.mark.test_release
+def test_skipped_blocks_under_ifdef(stable_test_dir: Path) -> None:
+    import tests.python.refl.refl_test_driver as refl_test_driver
+
+    incl: pb.IncludeVisit = refl_test_driver.get_include_tree(
+        {
+            "main.hpp":
+                '#include "cond.hpp"',
+            "cond.hpp":
+                "\n".join([
+                    "#if 0",
+                    "int skip1;",
+                    "int skip2;",
+                    "#endif",
+                    "int live;",
+                ]),
+        },
+        main_file_suffix="main.hpp",
+        stable_test_dir=stable_test_dir,
+    )
+
+    cond = incl.nested[0]
+    assert cond.relative_path == "cond.hpp"
+    assert cond.include_location_line == 1
+    assert cond.file_line_count == 5
+    assert cond.used_line_count == 1
+
+
+@pytest.mark.test_release
+def test_include_guard_header_included_twice(stable_test_dir: Path) -> None:
+    import tests.python.refl.refl_test_driver as refl_test_driver
+
+    incl: pb.IncludeVisit = refl_test_driver.get_include_tree(
+        {
+            "main.hpp":
+                '#include "guarded.hpp"\n#include "guarded.hpp"',
+            "guarded.hpp":
+                "#ifndef GUARDED_HPP\n#define GUARDED_HPP\nint guarded;\n#endif",
+        },
+        main_file_suffix="main.hpp",
+        stable_test_dir=stable_test_dir,
+    )
+
+    assert len(incl.nested) == 1
+    guarded = incl.nested[0]
+    assert guarded.relative_path == "guarded.hpp"
+    assert guarded.include_location_line == 1
+    assert guarded.file_line_count == 4
+    assert guarded.used_line_count == 4
+
+
+@pytest.mark.test_release
+def test_deep_nested_include_eventually_reaches_stdlib(stable_test_dir: Path) -> None:
+    import tests.python.refl.refl_test_driver as refl_test_driver
+
+    incl: pb.IncludeVisit = refl_test_driver.get_include_tree(
+        {
+            "a.hpp": '#include "b.hpp"',
+            "b.hpp": '#include "dir/c.hpp"\nint b;',
+            "dir/c.hpp": '#include "../d.hpp"\nint c;',
+            "d.hpp": "#include <string>\nint d;",
+        },
+        main_file_suffix="a.hpp",
+        stable_test_dir=stable_test_dir,
+    )
+
+    b = incl.nested[0]
+    c = b.nested[0]
+    d = c.nested[0]
+    std = d.nested[0]
+
+    assert b.relative_path == "b.hpp"
+    assert b.include_location_line == 1
+    assert b.file_line_count == 2
+    assert b.used_line_count == 2
+
+    assert c.relative_path == "dir/c.hpp"
+    assert c.include_location_line == 1
+    assert c.file_line_count == 2
+    assert c.used_line_count == 2
+
+    assert d.relative_path == "../d.hpp"
+    assert d.include_location_line == 1
+    assert d.file_line_count == 2
+    assert d.used_line_count == 2
+
+    assert std.relative_path == "string"
+    assert std.absolute_path
+    assert 0 < std.file_line_count
+    assert 0 < std.used_line_count <= std.file_line_count


### PR DESCRIPTION
Collect branching tree of includes in every translation unit, together
with the line count for them. Use this to determine the heaviest headers, maybe split, forward declare them. 

<img width="3658" height="2600" alt="Vec hpp_branch" src="https://github.com/user-attachments/assets/5aa99c69-c15b-4682-b62c-3943b2a169ed" />

